### PR TITLE
Remove lapacke library link option if not needed

### DIFF
--- a/computeCalib/CMakeLists.txt
+++ b/computeCalib/CMakeLists.txt
@@ -44,8 +44,10 @@ set(LINKLIBS
 	CLIcore
 	milkinfo
 	cacaoAOloopControl
-	lapacke
 )
+if(NOT MKL_FOUND)
+  list(APPEND LINKLIBS lapacke)
+endif()
 
 
 


### PR DESCRIPTION
This has been made necessary by [this commit](https://github.com/milk-org/milk/commit/07f1cd4e2fd406269342ac5d88dc0bc4ccd34336) cf. [here](https://github.com/milk-org/milk/blame/dev/CMakeLists.txt#L43), which broke the milk build.

I have another pull request in milk that applies essentially the same fix by having milk's fetch_cacao_dev.sh edit this file, but this is a better way to accomplish the same thing.

