### PR TITLE
separate gain and leak in modal filter

### DIFF
--- a/AOloopControl/modalfilter.c
+++ b/AOloopControl/modalfilter.c
@@ -1266,7 +1266,6 @@ static errno_t compute_function()
                 // multiply by GAIN
                 dmval *= imgmgain.im->array.F[mi];
 
-
                 //add the new delta command to the integrated command with leak: this is the goal position
                 mvalDMc[mi] = dmval + mvalDMc[mi]*imgmmult.im->array.F[mi];
 

--- a/AOloopControl/modalfilter.c
+++ b/AOloopControl/modalfilter.c
@@ -1267,11 +1267,8 @@ static errno_t compute_function()
                 dmval *= imgmgain.im->array.F[mi];
 
 
-                // this is the goal position
-                mvalDMc[mi] += dmval;
-
-                // multiply goal position by MULT
-                mvalDMc[mi] *= imgmmult.im->array.F[mi];
+                //add the new delta command to the integrated command with leak: this is the goal position
+                mvalDMc[mi] = dmval + mvalDMc[mi]*imgmmult.im->array.F[mi];
 
                 // apply LIMIT
                 limit = imgmlimit.im->array.F[mi];


### PR DESCRIPTION
This modifies `modalfilter.c` so that gain and leak are fully independent , which I think is the proper form of the leaky integrator.   

I tested this with the simulator on scexao-vispyr-bin2 with no noticeable change in behavior.   

The effects of this should be subtle and probably negligible in the usual case where mult. coef. is close to 1.  It's probably worth being correct, and this could help with things like transfer function analysis and gain optimization.