### PR TITLE
Build on MagAO-X RTC (CentOS 7)

### DIFF
--- a/AOloopControl/examples/scexao-vispyr-bin2-conf/README.md
+++ b/AOloopControl/examples/scexao-vispyr-bin2-conf/README.md
@@ -235,11 +235,6 @@ cacao-aorun-070-cmval2dm start
 
 ```
 
-
-python -m pycacao.calib.mkmodes randhad HpokeCrand.fits (edited) 
-python -m pycacao.calib.rmdecode
-
-
 Closing the loop and setting loop parameters with mfilt:
 
 ```bash

--- a/AOloopControl/examples/scexao-vispyr-bin2-conf/simLHS/respM.fits.get.bash
+++ b/AOloopControl/examples/scexao-vispyr-bin2-conf/simLHS/respM.fits.get.bash
@@ -6,9 +6,9 @@ if [ ! -f $FILENAME ]; then
 
     ggID='1MnNo9WfRHuKik3gpEHEjZHgt8_PM0T1a'
     ggURL='https://drive.google.com/uc?export=download'
-    filename="$(curl -sc /tmp/gcokie "${ggURL}&id=${ggID}" | grep -o '="uc-name.*</span>' | sed 's/.*">//;s/<.a> .*//')"
-    getcode="$(awk '/_warning_/ {print $NF}' /tmp/gcokie)"
-    curl -Lb /tmp/gcokie "${ggURL}&confirm=${getcode}&id=${ggID}" -o "${filename}"
+    filename="$(curl -sc /tmp/gcookie "${ggURL}&id=${ggID}" | grep -o '="uc-name.*</span>' | sed 's/.*">//;s/<.a> .*//')"
+    getcode="$(awk '/_warning_/ {print $NF}' /tmp/gcookie)" || touch /tmp/gcookie
+    curl -Lb /tmp/gcookie "${ggURL}&confirm=${getcode}&id=${ggID}" -o "${filename}"
     mv scexao-vispyr-bin2-zrespM.fits ${FILENAME}
 
 fi

--- a/computeCalib/CMakeLists.txt
+++ b/computeCalib/CMakeLists.txt
@@ -45,7 +45,8 @@ set(LINKLIBS
 	milkinfo
 	cacaoAOloopControl
 )
-if(NOT MKL_FOUND)
+
+if((NOT MKL_FOUND) AND (NOT OPENBLAS_FOUND))
   list(APPEND LINKLIBS lapacke)
 endif()
 


### PR DESCRIPTION
A few tweaks from build on current (though soon-to-be-upgraded) MagAO-X RTC.  With these changes we can go all the way through the scexao-vispyr-bin2 example to a closed loop.

Note that the fix for the curl cookie file (66186d2) might need to be added to all the examples.   Could just be a quirk of older curl version on COS-7.

On 69352a4 lapacke doesn't always get installed.  Even in cases where it is, I don't think we want to link against if either openblas or MKL are available since they have optimized lapack routines included.

