### PR TITLE
updated archive/apply scripts to work mostly like before.  

### DIFF
--- a/AOloopControl/scripts/cacao-calib-apply
+++ b/AOloopControl/scripts/cacao-calib-apply
@@ -13,16 +13,8 @@ source cacao-check-cacaovars
 RequiredCommands=(milk)
 RequiredPipes=()
 RequiredFiles=()
-RequiredDirs=(AOcalibs)
 
 MSarg+=( "calibname:string:calibration name" )
-
-MSopt+=( "w:wfsdiag:setwfsdiag::use WFS-diagonalized modes" )
-WFSdiag="0"
-function setwfsdiag() {
-	echo "Using WFS-diagonalized modes"
-	WFSdiag="1"
-}
 
 
 source milk-argparse
@@ -38,95 +30,38 @@ set -u
 calib="${inputMSargARRAY[0]}"
 echo "Calibration : ${calib}"
 
+#Directory name
+BASEARCHDIR="../${CACAO_LOOPNAME}-calibs/"
+ARCHDIR="${BASEARCHDIR}${calib}/"
 
-
-
-
-
-# Arguments:
-# Calib name
-
-
-
-ARCHDIR="AOcalibs/${calib}"
 
 echo "Loop ${CACAO_LOOPNUMBER}: Loading calibration from ${ARCHDIR}"
 
 if [[ -d "${ARCHDIR}" ]]; then
 
-
-if [ "${WFSdiag}" = "1" ]; then
-
-# wfsdiag.txt records which basis was loaded
-echo 1 > $MILK_SHM_DIR/aol${CACAO_LOOPNUMBER}_calib_wfsdiag.txt
-
-MILK_QUIET=1 milk << EOF
-
-loadfits "${ARCHDIR}/aol${CACAO_LOOPNUMBER}_modesWFS_WFSdiag.fits" aolmWFS
-imcpshm aolmWFS aol${CACAO_LOOPNUMBER}_modesWFS
-
-loadfits "${ARCHDIR}/aol${CACAO_LOOPNUMBER}_DMmodes_WFSdiag.fits" aolmDM
-imcpshm aolmDM  aol${CACAO_LOOPNUMBER}_DMmodes
-
-exitCLI
-EOF
-
-else
+# Load CM to shared memory
+milk-FITS2shm "${ARCHDIR}/CMmodesWFS/CMmodesWFS.fits" aol${CACAO_LOOPNUMBER}_modesWFS
+milk-FITS2shm "${ARCHDIR}/CMmodesDM/CMmodesDM.fits" aol${CACAO_LOOPNUMBER}_DMmodes
 
 
-# wfsdiag.txt records which basis was loaded
-echo 0 > $MILK_SHM_DIR/aol${CACAO_LOOPNUMBER}_calib_wfsdiag.txt
+milk-FITS2shm "${ARCHDIR}/shmim.aol${CACAO_LOOPNUMBER}_wfsref.fits" aol${CACAO_LOOPNUMBER}_wfsref
+milk-FITS2shm "${ARCHDIR}/shmim.aol${CACAO_LOOPNUMBER}_wfsrefc.fits" aol${CACAO_LOOPNUMBER}_wfsrefc
 
-MILK_QUIET=1 milk << EOF
+milk-FITS2shm "${ARCHDIR}/shmim.aol${CACAO_LOOPNUMBER}_wfsmask.fits" aol${CACAO_LOOPNUMBER}_wfsmask
+milk-FITS2shm "${ARCHDIR}/shmim.aol${CACAO_LOOPNUMBER}_wfsmap.fits" aol${CACAO_LOOPNUMBER}_wfsmap
 
-loadfits "${ARCHDIR}/aol${CACAO_LOOPNUMBER}_modesWFS.fits" aolmWFS
-imcpshm aolmWFS aol${CACAO_LOOPNUMBER}_modesWFS
+milk-FITS2shm "${ARCHDIR}/shmim.aol${CACAO_LOOPNUMBER}_dmmask.fits" aol${CACAO_LOOPNUMBER}_dmmask
+milk-FITS2shm "${ARCHDIR}/shmim.aol${CACAO_LOOPNUMBER}_dmmap.fits" aol${CACAO_LOOPNUMBER}_dmmap
 
-loadfits "${ARCHDIR}/aol${CACAO_LOOPNUMBER}_DMmodes.fits" aolmDM
-imcpshm aolmDM  aol${CACAO_LOOPNUMBER}_DMmodes
-
-exitCLI
-EOF
-
-fi
-
-
-
-MILK_QUIET=1 milk <<EOF
-
-loadfits "${ARCHDIR}/aol${CACAO_LOOPNUMBER}_wfsref.fits" aolwfsref
-imcpshm aolwfsref aol${CACAO_LOOPNUMBER}_wfsref
-
-loadfits "${ARCHDIR}/aol${CACAO_LOOPNUMBER}_wfsmask.fits" aolwfsmask
-imcpshm aolwfsmask aol${CACAO_LOOPNUMBER}_wfsmask
-
-
-loadfits "${ARCHDIR}/aol${CACAO_LOOPNUMBER}_wfsmap.fits" aolwfsmap
-imcpshm aolwfsmap aol${CACAO_LOOPNUMBER}_wfsmap
-
-loadfits "${ARCHDIR}/aol${CACAO_LOOPNUMBER}_dmmask.fits" aoldmmask
-imcpshm aoldmmask aol${CACAO_LOOPNUMBER}_dmmask
-
-loadfits "${ARCHDIR}/aol${CACAO_LOOPNUMBER}_dmslaved.fits" aoldmslaved
-imcpshm aoldmslaved aol${CACAO_LOOPNUMBER}_dmslaved
-
-loadfits "${ARCHDIR}/aol${CACAO_LOOPNUMBER}_zrespM.fits" aolzrespM
-imcpshm aolzrespM aol${CACAO_LOOPNUMBER}_zrespM
-
-loadfits "${ARCHDIR}/aol${CACAO_LOOPNUMBER}_LOrespM.fits" aolLOrespM
-imcpshm aolLOrespM aol${CACAO_LOOPNUMBER}_LOrespM
-
-loadfits "${ARCHDIR}/aol${CACAO_LOOPNUMBER}_LODMmodes.fits" aolLODMmodes
-imcpshm aolLODMmodes aol${CACAO_LOOPNUMBER}_LODMmodes
-
-exitCLI
-EOF
 
 # record this calib as applied
-# TODO: is there a standard logger we should invoke?
-echo $(pwd)/${ARCHDIR} > $MILK_SHM_DIR/aol${CACAO_LOOPNUMBER}_calib_source.txt
-echo $(date -u --iso-8601=seconds) > $MILK_SHM_DIR/aol${CACAO_LOOPNUMBER}_calib_loaded.txt
-echo "$(date -u --iso-8601=seconds) APPLY ${calib}" >> AOcalibs/AOcalib-${CACAO_LOOPNUMBER}-log.txt
+echo $(pwd)/../${ARCHDIR} > $MILK_SHM_DIR/aol${CACAO_LOOPNUMBER}_calib_source.txt
+
+DATESTRING="$(date -u --iso-8601=seconds)"
+
+echo ${DATESTRING} > $MILK_SHM_DIR/aol${CACAO_LOOPNUMBER}_calib_loaded.txt
+
+echo "${DATESTRING} APPLY ${calib}" >> ${BASEARCHDIR}/aol${CACAO_LOOPNUMBER}_archive-log.txt
 
 
 else

--- a/AOloopControl/scripts/cacao-calib-archive
+++ b/AOloopControl/scripts/cacao-calib-archive
@@ -18,14 +18,14 @@ RequiredDirs=(conf)
 
 
 
-#MSarg+=( "calibname:string:calibration name" )
+MSarg+=( "calibname:string:calibration name" )
+MSopt+=( "u:update:setupdate::update existing, do not append timestamp" )
 
-#MSopt+=( "t:timestamp:settimestamp::append timestamp to name" )
-#addtimestamp="0"
-#function settimestamp() {
-#        echo "Append timestamp to name"
-#        addtimestamp="1"
-#}
+update="0"
+function setupdate() {
+        echo "Updating, not apppending timestamp"
+        update="1"
+}
 
 
 
@@ -39,23 +39,26 @@ set -u
 
 
 
-#calib="${inputMSargARRAY[0]}"
-#echo "Calibration : ${calib}"
+calib="${inputMSargARRAY[0]}"
+echo "Calibration : ${calib}"
 
 
 
 
+DATESTRING="$(date -u --iso-8601=seconds)"
 
-# Arguments:
-# Calib name
+#The purpose of appending a timestamp is to make a unique directory name.  The pretty version is written inside the directory.
+TIMESTAMP="$(date -u +%Y%m%d_%H%M%S -d ${DATESTRING})"
 
-DATESTRING="$(date -u +%Y-%m-%dT%H:%M:%S)"
 
-ARCHDIR="../${CACAO_LOOPNAME}-calibs/${DATESTRING}/"
+#Append the date/time if not turned off
+if [ "${update}" = "0" ]; then
+    calib=${calib}_${TIMESTAMP}
+fi
 
-#if [ "${addtimestamp}" = "1" ]; then
-#ARCHDIR=${ARCHDIR}_$(date -u +%Y-%m-%dT%H:%M:%S)
-#fi
+#Directory name
+BASEARCHDIR="../${CACAO_LOOPNAME}-calibs/"
+ARCHDIR="${BASEARCHDIR}${calib}/"
 
 
 mkdir -p ${ARCHDIR}
@@ -72,50 +75,24 @@ do
     then
         for ff in $f/*
         do      
-            echo "Processing $ff"
+            #if this is a broken symlink, ignore it
+            if [ -L $ff ] && [ ! -e $ff ] 
+            then
+                continue
+            fi
+
+	        cp -L -r $ff ${ARCHDIR}"$(basename $ff)"
         done
     else
-        echo "Processing file $f"
+        cp -L -r $ff ${ARCHDIR}
     fi
 done
-
-
-exit 0
-
-cp ${CACAO_LOOPRUNDIR}/fps.compfCM-${CACAO_LOOPNUMBER}.datadir/mkmodestmp/fmodesWFS1all.fits ${ARCHDIR}/aol${CACAO_LOOPNUMBER}_modesWFS.fits
-cp ${CACAO_LOOPRUNDIR}/fps.compfCM-${CACAO_LOOPNUMBER}.datadir/mkmodestmp/fmodes2ball.fits ${ARCHDIR}/aol${CACAO_LOOPNUMBER}_DMmodes.fits
-
-# modes including WFS-space diagonalization
-cp ${CACAO_LOOPRUNDIR}/fps.compfCM-${CACAO_LOOPNUMBER}.datadir/mkmodestmp/fmodesWFSall.fits ${ARCHDIR}/aol${CACAO_LOOPNUMBER}_modesWFS_WFSdiag.fits
-cp ${CACAO_LOOPRUNDIR}/fps.compfCM-${CACAO_LOOPNUMBER}.datadir/mkmodestmp/fmodesall.fits ${ARCHDIR}/aol${CACAO_LOOPNUMBER}_DMmodes_WFSdiag.fits
-
-# copy the block structure files
-cp ${CACAO_LOOPRUNDIR}/fps.compfCM-${CACAO_LOOPNUMBER}.datadir/param_NBmodeblocks.txt ${ARCHDIR}/aol${CACAO_LOOPNUMBER}_NBmodeblocks.txt
-cp ${CACAO_LOOPRUNDIR}/fps.compfCM-${CACAO_LOOPNUMBER}.datadir/param_NBmodes.txt ${ARCHDIR}/aol${CACAO_LOOPNUMBER}_NBmodes.txt
-
-# and copy the block files for future reference
-for f in $(ls ${CACAO_LOOPRUNDIR}/fps.compfCM-${CACAO_LOOPNUMBER}.datadir/block*.txt) ; do
-   cp $f ${ARCHDIR}/aol${CACAO_LOOPNUMBER}_$(basename $f)
-done
-
-
-
-cp ${CACAO_LOOPRUNDIR}/fps.acqlin_zRM-${CACAO_LOOPNUMBER}.datadir/wfsref_mn.fits ${ARCHDIR}/aol${CACAO_LOOPNUMBER}_wfsref.fits
-cp ${CACAO_LOOPRUNDIR}/fps.acqlin_zRM-${CACAO_LOOPNUMBER}.datadir/wfsmask_mkm.fits ${ARCHDIR}/aol${CACAO_LOOPNUMBER}_wfsmask.fits
-cp ${CACAO_LOOPRUNDIR}/fps.acqlin_zRM-${CACAO_LOOPNUMBER}.datadir/wfsmap.fits ${ARCHDIR}/aol${CACAO_LOOPNUMBER}_wfsmap.fits
-cp ${CACAO_LOOPRUNDIR}/fps.acqlin_zRM-${CACAO_LOOPNUMBER}.datadir/dmmask_mkm.fits ${ARCHDIR}/aol${CACAO_LOOPNUMBER}_dmmask.fits
-cp ${CACAO_LOOPRUNDIR}/fps.acqlin_zRM-${CACAO_LOOPNUMBER}.datadir/dmslaved.fits ${ARCHDIR}/aol${CACAO_LOOPNUMBER}_dmslaved.fits
-cp ${CACAO_LOOPRUNDIR}/fps.acqlin_zRM-${CACAO_LOOPNUMBER}.datadir/zrespM.fits ${ARCHDIR}/aol${CACAO_LOOPNUMBER}_zrespM.fits
-
-
-cp ${CACAO_LOOPRUNDIR}/fps.acqlin_loRM-${CACAO_LOOPNUMBER}.datadir/respM.fits ${ARCHDIR}/aol${CACAO_LOOPNUMBER}_LOrespM.fits
-cp ${CACAO_LOOPRUNDIR}/fps.acqlin_loRM-${CACAO_LOOPNUMBER}.datadir/RMpokeCube.fits ${ARCHDIR}/aol${CACAO_LOOPNUMBER}_LODMmodes.fits
 
 
 # write out complete path so someone following a symlink can easily track where we are
 echo $(pwd)/${ARCHDIR} > ${ARCHDIR}/aol${CACAO_LOOPNUMBER}_calib_dir.txt
 
 # append timestamp
-echo $(date -u --iso-8601=seconds) >> ${ARCHDIR}/aol${CACAO_LOOPNUMBER}_calib_archived.txt
+echo ${DATESTRING} >> ${ARCHDIR}/aol${CACAO_LOOPNUMBER}_calib_archived.txt
 
-echo "$(date -u --iso-8601=seconds) ARCHIVE ${calib}" >> AOcalibs/AOcalib-${CACAO_LOOPNUMBER}-log.txt
+echo "${DATESTRING} ARCHIVED ${calib}" >> ${BASEARCHDIR}/aol${CACAO_LOOPNUMBER}_archive-log.txt


### PR DESCRIPTION
tested once on maps sim

reverted back to requiring a name and using timestamp by default in directory name.  So we get cal directories like `maps-calibs/cal1_20230920_175687/  This avoid having : in file names.

This currently dumps EVERYTHING from conf, and dereferences symlinks.  I think this ends up with significant duplication.

I don't use the CACAO logging system, so this may not do it right.