### PR TITLE
use lapacke symbols in openblas if available

### DIFF
--- a/computeCalib/CMakeLists.txt
+++ b/computeCalib/CMakeLists.txt
@@ -46,10 +46,21 @@ set(LINKLIBS
 	cacaoAOloopControl
 )
 
+#If not using MKL, check if OpenBLAS has lapacke symbols.  Include lapacke if not.
 if(NOT MKL_FOUND)
-  list(APPEND LINKLIBS lapacke)
-endif()
 
+    check_library_exists(openblas LAPACKE_sgemlq "" DONT_NEED_LAPACKE)
+
+    if(DONT_NEED_LAPACKE)
+       message("-- MKL NOT FOUND")
+       message("   LINKING OpenBLAS")
+    else()
+       message("-- MKL NOT FOUND")
+       message("   LINKING LAPACKE")
+       list(APPEND LINKLIBS lapacke)    
+    endif()
+
+endif()
 
 
 


### PR DESCRIPTION
OpenBLAS normally provides lapacke symbols, and when true installing a separate liblapacke is not necessary and may degrade performance since OpenBLAS has its own optimizations.

The ubuntu-packaged OpenBLAS does NOT, however, provide lapacke.

This handles both cases.