### PR TITLE
Fix snprintf truncation warnings in streamlogtimesample.c

### DIFF
--- a/AOloopControl_perfTest/streamlogtimesample.c
+++ b/AOloopControl_perfTest/streamlogtimesample.c
@@ -490,7 +490,7 @@ static errno_t processTimingFile(
 static FPS_CLI_BINDING my_bindings[] = {
     FPS_PARAMS(FPS_X_BINDING)
 };
-static int nb_bindings = sizeof(my_bindings) / sizeof(FPS_CLI_BINDING);
+static int __attribute__((unused)) nb_bindings = sizeof(my_bindings) / sizeof(FPS_CLI_BINDING);
 
 static CLICMDARGDEF farg[] = {
     FPS_PARAMS(FPS_X_FARG)
@@ -745,8 +745,8 @@ static errno_t compute_function()
                 printf("LOADING TXT FILE\n");
                 fflush(stdout);
 
-                char fnameTXT[STRINGMAXLEN_FULLFILENAME];
-                WRITE_FILENAME(fnameTXT,
+                char fnameTXT[STRINGMAXLEN_FULLFILENAME + STRINGMAXLEN_DIRNAME];
+                snprintf(fnameTXT, sizeof(fnameTXT),
                                "%s/%s.txt",
                                datadirstream,
                                datfile[idatfile].name);
@@ -774,7 +774,7 @@ static errno_t compute_function()
 
                 {
                     char fnameTXTout[STRINGMAXLEN_FULLFILENAME];
-                    WRITE_FILENAME(fnameTXTout,
+                    WRITE_FULLFILENAME(fnameTXTout,
                                    "%s.out.txt",
                                    datfile[idatfile].name);
                     if(*lintiming[sindex] == 1)
@@ -881,8 +881,8 @@ static errno_t compute_function()
                     // load relevant section of input data cube
                     //
                     imageID IDc;
-                    char fnameFITS[STRINGMAXLEN_FULLFILENAME];
-                    WRITE_FILENAME(fnameFITS,
+                    char fnameFITS[STRINGMAXLEN_FULLFILENAME + STRINGMAXLEN_DIRNAME + 128];
+                    snprintf(fnameFITS, sizeof(fnameFITS),
                                    "%s/%s%s.fits[*,*,%ld:%ld]",
                                    datadirstream,
                                    datfile[idatfile].name,


### PR DESCRIPTION
### Prompt Summary
The user requested to fix remaining compiler warnings across the milk and cacao framework.

### AI Authorship
- **Model(s) used:** Antigravity
- **User edits:** None

### Motivation
This PR fixes `snprintf` format truncation compilation warnings in `streamlogtimesample.c` inside `cacao` due to buffers being too small to safely format the strings.

### What Changed
- **Buffer capacities:** Increased string buffer allocations where truncation was occurring.

### Testing Done
- Compiled the framework and verified that ALL `snprintf` warnings are resolved in `cacao`.