### PR TITLE
fix: resolve FPS parameter buffer overflows by removing pointer-to-pointer allocations

### DIFF
--- a/AOloopControl/modalfilter.c
+++ b/AOloopControl/modalfilter.c
@@ -38,54 +38,54 @@ static FPS_APP_INFO FPS_app_info = {
  * 2.  LOCAL PARAMETER VARIABLES
  * ============================================================= */
 
-static char     *inmval_ptr             = NULL;
-static char     *outmval_ptr            = NULL;
-static float    *loopgain_ptr           = NULL;
-static float    *loopmult_ptr           = NULL;
-static float    *looplimit_ptr          = NULL;
-static uint64_t *loopZERO_ptr           = NULL;
-static uint64_t *AOloopindex_ptr        = NULL;
-static uint64_t *loopON_ptr             = NULL;
-static int64_t  *loopNBstep_ptr         = NULL;
-static uint64_t *compOL_ptr             = NULL;
-static float    *psol_WFSfact_ptr       = NULL;
-static float    *latencyhardwfr_ptr     = NULL;
-static float    *latencysoftwfr_ptr     = NULL;
-static uint64_t *comptbuff_ptr          = NULL;
-static uint64_t *autolim_ptr            = NULL;
-static float    *autolimprobegain_ptr   = NULL;
-static float    *autolimsigmafact_ptr   = NULL;
-static uint32_t *tbuffsize_ptr          = NULL;
-static uint64_t *auxDMmvalenable_ptr    = NULL;
-static float    *auxDMmvalmixfact_ptr   = NULL;
-static uint64_t *auxDMmvalmodulate_ptr  = NULL;
-static float    *auxDMmvalmodperiod_ptr = NULL;
-static uint64_t *enablePF_ptr           = NULL;
-static uint32_t *PF_NBblock_ptr         = NULL;
-static uint32_t *PF_maxwaitus_ptr       = NULL;
-static float    *PFmixcoeff_ptr         = NULL;
-static uint64_t *autoloopenable_ptr     = NULL;
-static float    *autoloopsleep_ptr      = NULL;
-static uint64_t *selfRMenable_ptr       = NULL;
-static uint32_t *selfRMnbmode_ptr       = NULL;
-static float    *selfRMpokeampl_ptr     = NULL;
-static uint32_t *selfRMzsize_ptr        = NULL;
-static uint32_t *selfRMnbiter_ptr       = NULL;
-static uint32_t *selfRMnbsettlestep_ptr = NULL;
-static uint64_t *testOL_ptr             = NULL;
-static uint64_t *testOLloop_ptr         = NULL;
-static float    *testOLupdategain_ptr   = NULL;
-static uint32_t *testOLmode_ptr         = NULL;
-static float    *testOLampl_ptr         = NULL;
-static uint32_t *testOLnbsample_ptr     = NULL;
-static uint32_t *testOLcnt_ptr          = NULL;
-static uint64_t *offload_ptr            = NULL;
-static float    *offloadloopgain_ptr    = NULL;
-static float    *offloadloopmult_ptr    = NULL;
-static float    *offloadlooplimit_ptr   = NULL;
-static uint64_t *recburst_ptr           = NULL;
-static uint32_t *recburst_mode_ptr      = NULL;
-static uint32_t *recburst_nbsample_ptr  = NULL;
+static char inmval[FUNCTION_PARAMETER_STRMAXLEN] = "";
+static char outmval[FUNCTION_PARAMETER_STRMAXLEN] = "";
+static float loopgain = 0;
+static float loopmult = 0;
+static float looplimit = 0;
+static uint64_t loopZERO = 0;
+static uint64_t AOloopindex = 0;
+static uint64_t loopON = 0;
+static int64_t loopNBstep = 0;
+static uint64_t compOL = 0;
+static float psol_WFSfact = 0;
+static float latencyhardwfr = 0;
+static float latencysoftwfr = 0;
+static uint64_t comptbuff = 0;
+static uint64_t autolim = 0;
+static float autolimprobegain = 0;
+static float autolimsigmafact = 0;
+static uint32_t tbuffsize = 0;
+static uint64_t auxDMmvalenable = 0;
+static float auxDMmvalmixfact = 0;
+static uint64_t auxDMmvalmodulate = 0;
+static float auxDMmvalmodperiod = 0;
+static uint64_t enablePF = 0;
+static uint32_t PF_NBblock = 0;
+static uint32_t PF_maxwaitus = 0;
+static float PFmixcoeff = 0;
+static uint64_t autoloopenable = 0;
+static float autoloopsleep = 0;
+static uint64_t selfRMenable = 0;
+static uint32_t selfRMnbmode = 0;
+static float selfRMpokeampl = 0;
+static uint32_t selfRMzsize = 0;
+static uint32_t selfRMnbiter = 0;
+static uint32_t selfRMnbsettlestep = 0;
+static uint64_t testOL = 0;
+static uint64_t testOLloop = 0;
+static float testOLupdategain = 0;
+static uint32_t testOLmode = 0;
+static float testOLampl = 0;
+static uint32_t testOLnbsample = 0;
+static uint32_t testOLcnt = 0;
+static uint64_t offload = 0;
+static float offloadloopgain = 0;
+static float offloadloopmult = 0;
+static float offloadlooplimit = 0;
+static uint64_t recburst = 0;
+static uint32_t recburst_mode = 0;
+static uint32_t recburst_nbsample = 0;
 
 static uint64_t processinfo_change_cnt_local = 0;
 
@@ -194,26 +194,26 @@ static MFILT_STATE* modal_filter_init(uint32_t NBmode) {
     
     char name[STRINGMAXLEN_STREAMNAME];
     
-    WRITE_IMAGENAME(name, "aol%lu_modevalOL", *AOloopindex_ptr);
+    WRITE_IMAGENAME(name, "aol%lu_modevalOL", AOloopindex);
     state->imgOLmval = stream_connect_create_2Df32(name, NBmode, 1);
     
-    WRITE_IMAGENAME(name, "aol%lu_modevalauxDM", *AOloopindex_ptr);
+    WRITE_IMAGENAME(name, "aol%lu_modevalauxDM", AOloopindex);
     state->imgauxmDM = stream_connect_create_2Df32(name, NBmode, 1);
     
     // PF
-    WRITE_IMAGENAME(name, "aol%lu_modevalPF", *AOloopindex_ptr);
+    WRITE_IMAGENAME(name, "aol%lu_modevalPF", AOloopindex);
     state->imgmvalPF = stream_connect_create_2Df32(name, NBmode, 1);
     
-    WRITE_IMAGENAME(name, "aol%lu_mPFmixfact", *AOloopindex_ptr);
+    WRITE_IMAGENAME(name, "aol%lu_mPFmixfact", AOloopindex);
     state->imgmPFmixfact = stream_connect_create_2Df32(name, NBmode, 1);
     for(uint32_t mi=0; mi<NBmode; mi++) state->imgmPFmixfact.im->array.F[mi] = 1.0;
     ImageStreamIO_UpdateIm(state->imgmPFmixfact.im);
 
-    WRITE_IMAGENAME(name, "aol%lu_mPFmix", *AOloopindex_ptr);
+    WRITE_IMAGENAME(name, "aol%lu_mPFmix", AOloopindex);
     state->imgmPFmix = stream_connect_create_2Df32(name, NBmode, 1);
     
     int PFcbuff_size = 20;
-    WRITE_IMAGENAME(name, "aol%lu_modevalPF_cbuff", *AOloopindex_ptr);
+    WRITE_IMAGENAME(name, "aol%lu_modevalPF_cbuff", AOloopindex);
     state->imgcbuff_mvalPF = stream_connect_create_2Df32(name,
         PFcbuff_size,
         NBmode);
@@ -222,64 +222,64 @@ static MFILT_STATE* modal_filter_init(uint32_t NBmode) {
     state->mvalPFold = (double*) calloc(NBmode, sizeof(double));
     
     // GAIN/MULT/LIMIT
-    WRITE_IMAGENAME(name, "aol%lu_mgain", *AOloopindex_ptr);
+    WRITE_IMAGENAME(name, "aol%lu_mgain", AOloopindex);
     state->imgmgain = stream_connect_create_2Df32(name, NBmode, 1);
     
-    WRITE_IMAGENAME(name, "aol%lu_mgainfact", *AOloopindex_ptr);
+    WRITE_IMAGENAME(name, "aol%lu_mgainfact", AOloopindex);
     state->imgmgainfact = stream_connect_create_2Df32(name, NBmode, 1);
     for(uint32_t mi=0; mi<NBmode; mi++) state->imgmgainfact.im->array.F[mi] = 1.0;
     ImageStreamIO_UpdateIm(state->imgmgainfact.im);
 
-    WRITE_IMAGENAME(name, "aol%lu_mmult", *AOloopindex_ptr);
+    WRITE_IMAGENAME(name, "aol%lu_mmult", AOloopindex);
     state->imgmmult = stream_connect_create_2Df32(name, NBmode, 1);
 
-    WRITE_IMAGENAME(name, "aol%lu_mmultfact", *AOloopindex_ptr);
+    WRITE_IMAGENAME(name, "aol%lu_mmultfact", AOloopindex);
     state->imgmmultfact = stream_connect_create_2Df32(name, NBmode, 1);
     for(uint32_t mi=0; mi<NBmode; mi++) state->imgmmultfact.im->array.F[mi] = 1.0;
     ImageStreamIO_UpdateIm(state->imgmmultfact.im);
     
-    WRITE_IMAGENAME(name, "aol%lu_mzeropoint", *AOloopindex_ptr);
+    WRITE_IMAGENAME(name, "aol%lu_mzeropoint", AOloopindex);
     state->imgmzeropoint = stream_connect_create_2Df32(name, NBmode, 1);
 
-    WRITE_IMAGENAME(name, "aol%lu_mlimit", *AOloopindex_ptr);
+    WRITE_IMAGENAME(name, "aol%lu_mlimit", AOloopindex);
     state->imgmlimit = stream_connect_create_2Df32(name, NBmode, 1);
 
-    WRITE_IMAGENAME(name, "aol%lu_mlimitfact", *AOloopindex_ptr);
+    WRITE_IMAGENAME(name, "aol%lu_mlimitfact", AOloopindex);
     state->imgmlimitfact = stream_connect_create_2Df32(name, NBmode, 1);
     for(uint32_t mi=0; mi<NBmode; mi++) state->imgmlimitfact.im->array.F[mi] = 1.0;
     ImageStreamIO_UpdateIm(state->imgmlimitfact.im);
 
     // Offload
-    WRITE_IMAGENAME(name, "aol%lu_offloadmgain", *AOloopindex_ptr);
+    WRITE_IMAGENAME(name, "aol%lu_offloadmgain", AOloopindex);
     state->imgoffloadmgain = stream_connect_create_2Df32(name, NBmode, 1);
     
-    WRITE_IMAGENAME(name, "aol%lu_offloadmgainfact", *AOloopindex_ptr);
+    WRITE_IMAGENAME(name, "aol%lu_offloadmgainfact", AOloopindex);
     state->imgoffloadmgainfact = stream_connect_create_2Df32(name, NBmode, 1);
     for(uint32_t mi=0; mi<NBmode; mi++) state->imgoffloadmgainfact.im->array.F[mi] = 1.0;
     ImageStreamIO_UpdateIm(state->imgoffloadmgainfact.im);
 
-    WRITE_IMAGENAME(name, "aol%lu_offloadmmult", *AOloopindex_ptr);
+    WRITE_IMAGENAME(name, "aol%lu_offloadmmult", AOloopindex);
     state->imgoffloadmmult = stream_connect_create_2Df32(name, NBmode, 1);
 
-    WRITE_IMAGENAME(name, "aol%lu_offloadmmultfact", *AOloopindex_ptr);
+    WRITE_IMAGENAME(name, "aol%lu_offloadmmultfact", AOloopindex);
     state->imgoffloadmmultfact = stream_connect_create_2Df32(name, NBmode, 1);
     for(uint32_t mi=0; mi<NBmode; mi++) state->imgoffloadmmultfact.im->array.F[mi] = 1.0;
     ImageStreamIO_UpdateIm(state->imgoffloadmmultfact.im);
 
-    WRITE_IMAGENAME(name, "aol%lu_offloadmlimit", *AOloopindex_ptr);
+    WRITE_IMAGENAME(name, "aol%lu_offloadmlimit", AOloopindex);
     state->imgoffloadmlimit = stream_connect_create_2Df32(name, NBmode, 1);
 
-    WRITE_IMAGENAME(name, "aol%lu_offloadmlimitfact", *AOloopindex_ptr);
+    WRITE_IMAGENAME(name, "aol%lu_offloadmlimitfact", AOloopindex);
     state->imgoffloadmlimitfact = stream_connect_create_2Df32(name, NBmode, 1);
     for(uint32_t mi=0; mi<NBmode; mi++) state->imgoffloadmlimitfact.im->array.F[mi] = 1.0;
     ImageStreamIO_UpdateIm(state->imgoffloadmlimitfact.im);
     
-    WRITE_IMAGENAME(name, "aol%lu_mvaloffloadDM", *AOloopindex_ptr);
+    WRITE_IMAGENAME(name, "aol%lu_mvaloffloadDM", AOloopindex);
     state->imgmvaloffloadDM = stream_connect_create_2Df32(name, NBmode, 1);
 
     // Limit Counter
     state->mlimitcntarray = (long*) calloc(NBmode, sizeof(long));
-    WRITE_IMAGENAME(name, "aol%lu_mlimitcntfrac", *AOloopindex_ptr);
+    WRITE_IMAGENAME(name, "aol%lu_mlimitcntfrac", AOloopindex);
     state->imgmlimitcntfrac = stream_connect_create_2Df32(name, NBmode, 1);
     
     // Stats
@@ -294,33 +294,33 @@ static MFILT_STATE* modal_filter_init(uint32_t NBmode) {
     state->autolimDMsigma = (double*) calloc(NBmode, sizeof(double));
 
     // Telemetry Buffers
-    WRITE_IMAGENAME(name, "aol%lu_modevalDM_buff", *AOloopindex_ptr);
+    WRITE_IMAGENAME(name, "aol%lu_modevalDM_buff", AOloopindex);
     state->imgtbuff_mvalDM = stream_connect_create_3Df32(name,
         NBmode,
-        *tbuffsize_ptr,
+        tbuffsize,
         2);
-    WRITE_IMAGENAME(name, "aol%lu_modevalWFS_buff", *AOloopindex_ptr);
+    WRITE_IMAGENAME(name, "aol%lu_modevalWFS_buff", AOloopindex);
     state->imgtbuff_mvalWFS = stream_connect_create_3Df32(name,
         NBmode,
-        *tbuffsize_ptr,
+        tbuffsize,
         2);
-    WRITE_IMAGENAME(name, "aol%lu_modevalOL_buff", *AOloopindex_ptr);
+    WRITE_IMAGENAME(name, "aol%lu_modevalOL_buff", AOloopindex);
     state->imgtbuff_mvalOL = stream_connect_create_3Df32(name,
         NBmode,
-        *tbuffsize_ptr,
+        tbuffsize,
         2);
     
     // SelfRM
-    WRITE_IMAGENAME(name, "aol%lu_mfiltselfRM", *AOloopindex_ptr);
+    WRITE_IMAGENAME(name, "aol%lu_mfiltselfRM", AOloopindex);
     state->imgselfRM = stream_connect_create_3Df32(name,
         NBmode,
         NBmode,
-        *selfRMzsize_ptr);
+        selfRMzsize);
     state->selfRMpokecmd = (float*) calloc(NBmode, sizeof(float));
     state->selfRMpokesign = 1.0;
     
     // External DMf
-    WRITE_IMAGENAME(name, "aol%lu_modevalDMf", *AOloopindex_ptr);
+    WRITE_IMAGENAME(name, "aol%lu_modevalDMf", AOloopindex);
     state->imgmodevalDMf = stream_connect_create_2Df32(name, NBmode, 1);
     
     return state;
@@ -374,7 +374,7 @@ static void modal_filter_step(
     uint32_t NBmode = imginWFS->md[0].size[0];
 
     // Zero loop
-    if(loopZERO_ptr && ((*loopZERO_ptr) & FPFLAG_ONOFF)) {
+    if(loopZERO && ((loopZERO) & FPFLAG_ONOFF)) {
         for(uint32_t mi = 0; mi < NBmode; mi++) {
              state->mvalDMc[mi] = 0.0;
              state->mvalout[mi] = 0.0;
@@ -382,24 +382,24 @@ static void modal_filter_step(
         }
         memset(imgout->array.F, 0, sizeof(float) * NBmode);
         processinfo_update_output_stream(processinfo, imgout, NULL);
-        (*loopZERO_ptr) &= ~FPFLAG_ONOFF;
+        (loopZERO) &= ~FPFLAG_ONOFF;
     }
 
-    if((*loopON_ptr) == 1) {
-        if(*loopNBstep_ptr > 0) {
-            *loopNBstep_ptr = *loopNBstep_ptr - 1;
+    if((loopON) == 1) {
+        if(loopNBstep > 0) {
+            loopNBstep = loopNBstep - 1;
         }
-        if(*loopNBstep_ptr == 0) {
-            *loopON_ptr = 0;
-            (*loopON_ptr) &= ~FPFLAG_ONOFF;
-            *loopNBstep_ptr = 1;
+        if(loopNBstep == 0) {
+            loopON = 0;
+            (loopON) &= ~FPFLAG_ONOFF;
+            loopNBstep = 1;
         }
 
         // Aux DM factor
-        float auxDMfact = (*auxDMmvalmixfact_ptr);
-        if((*auxDMmvalmodulate_ptr) == 1) {
+        float auxDMfact = (auxDMmvalmixfact);
+        if((auxDMmvalmodulate) == 1) {
             static double modpha = 0.0;
-            modpha += 1.0 / (*auxDMmvalmodperiod_ptr);
+            modpha += 1.0 / (auxDMmvalmodperiod);
             if(modpha > 1.0) modpha -= 1.0;
             auxDMfact *= sinf(2.0f * M_PI * modpha);
         }
@@ -415,9 +415,9 @@ static void modal_filter_step(
 
         // Update Gain/Mult/Limit arrays
         for(uint32_t mi=0; mi<NBmode; mi++) {
-            state->imgmgain.im->array.F[mi] = state->imgmgainfact.im->array.F[mi] * (*loopgain_ptr);
-            state->imgmmult.im->array.F[mi] = state->imgmmultfact.im->array.F[mi] * (*loopmult_ptr);
-            state->imgmlimit.im->array.F[mi] = state->imgmlimitfact.im->array.F[mi] * (*looplimit_ptr);
+            state->imgmgain.im->array.F[mi] = state->imgmgainfact.im->array.F[mi] * (loopgain);
+            state->imgmmult.im->array.F[mi] = state->imgmmultfact.im->array.F[mi] * (loopmult);
+            state->imgmlimit.im->array.F[mi] = state->imgmlimitfact.im->array.F[mi] * (looplimit);
         }
         
         // Modal Control
@@ -437,7 +437,7 @@ static void modal_filter_step(
                 state->mlimitcntarray[mi]++;
             }
             
-            if((*auxDMmvalenable_ptr) == 1) {
+            if((auxDMmvalenable) == 1) {
                 state->mvalout[mi] = state->mvalDMc[mi] + (auxDMfact * state->imgauxmDM.im->array.F[mi]);
             } else {
                 state->mvalout[mi] = state->mvalDMc[mi];
@@ -447,18 +447,18 @@ static void modal_filter_step(
         state->modal_limit_counter++;
 
         // Output to stream if PF not enabled
-        if(*enablePF_ptr == 0) {
+        if(enablePF == 0) {
             memcpy(imgout->array.F,
                 state->mvaloutapply,
                 sizeof(float) * NBmode);
         }
 
         // Offload Loop
-        if((*offload_ptr) == 1) {
+        if((offload) == 1) {
             for(uint32_t mi=0; mi<NBmode; mi++) {
-                state->imgoffloadmgain.im->array.F[mi] = state->imgoffloadmgainfact.im->array.F[mi] * (*offloadloopgain_ptr);
-                state->imgoffloadmmult.im->array.F[mi] = state->imgoffloadmmultfact.im->array.F[mi] * (*offloadloopmult_ptr);
-                state->imgoffloadmlimit.im->array.F[mi] = state->imgoffloadmlimitfact.im->array.F[mi] * (*offloadlooplimit_ptr);
+                state->imgoffloadmgain.im->array.F[mi] = state->imgoffloadmgainfact.im->array.F[mi] * (offloadloopgain);
+                state->imgoffloadmmult.im->array.F[mi] = state->imgoffloadmmultfact.im->array.F[mi] * (offloadloopmult);
+                state->imgoffloadmlimit.im->array.F[mi] = state->imgoffloadmlimitfact.im->array.F[mi] * (offloadlooplimit);
 
                 float val = state->imgmvaloffloadDM.im->array.F[mi];
                 val += state->imgoffloadmgain.im->array.F[mi] * imgout->array.F[mi];
@@ -474,12 +474,12 @@ static void modal_filter_step(
         }
 
         // Compute OL
-        if((*compOL_ptr) == 1) {
+        if((compOL) == 1) {
             for(uint32_t mi=0; mi<NBmode; mi++) state->mvalDMbuff[state->DMtstep * NBmode + mi] = state->mvalDMc[mi];
             state->DMtstep++;
             if(state->DMtstep == 10) state->DMtstep = 0;
 
-            float latencytotalfr = (*latencyhardwfr_ptr) + (*latencysoftwfr_ptr);
+            float latencytotalfr = (latencyhardwfr) + (latencysoftwfr);
             int latint = (int)latencytotalfr;
             float latfrac = latencytotalfr - latint;
             int DMtstep1 = state->DMtstep - latint;
@@ -491,7 +491,7 @@ static void modal_filter_step(
                 float tmpmDMval = latfrac * state->mvalDMbuff[DMtstep0*NBmode + mi] + (1.0-latfrac)*state->mvalDMbuff[DMtstep1*NBmode + mi];
                 state->mvalDMOL[mi] = tmpmDMval;
                 float tmpmWFSval = imginWFS->array.F[mi];
-                state->imgOLmval.im->array.F[mi] = (*psol_WFSfact_ptr) * tmpmWFSval - state->mvalDMOL[mi];
+                state->imgOLmval.im->array.F[mi] = (psol_WFSfact) * tmpmWFSval - state->mvalDMOL[mi];
             }
             processinfo_update_output_stream(processinfo,
                 state->imgOLmval.im,
@@ -504,10 +504,10 @@ static void modal_filter_step(
  * @brief Basic parameter validation.
  */
 static void __attribute__((unused)) modalfilter_validate() {
-    if (loopgain_ptr && *loopgain_ptr < 0) *loopgain_ptr = 0;
-    if (loopmult_ptr && *loopmult_ptr < 0) *loopmult_ptr = 0;
-    if (loopmult_ptr && *loopmult_ptr > 1.0) *loopmult_ptr = 1.0;
-    if (looplimit_ptr && *looplimit_ptr < 0) *looplimit_ptr = 0;
+    if (loopgain < 0) loopgain = 0;
+    if (loopmult < 0) loopmult = 0;
+    if (loopmult > 1.0) loopmult = 1.0;
+    if (looplimit < 0) looplimit = 0;
 }
 
 
@@ -516,230 +516,230 @@ static void __attribute__((unused)) modalfilter_validate() {
  * ============================================================= */
 
 #define FPS_PARAMS(X) \
-    X(".inmval", &inmval_ptr, \
+    X(".inmval", inmval, \
       FPTYPE_STREAMNAME, 1, \
       FPFLAG_DEFAULT_INPUT \
           | FPFLAG_PRIMARY_CLI_INPUT \
           | FPFLAG_STREAM_RUN_REQUIRED \
           | FPFLAG_CHECKSTREAM, \
       "input mode values from WFS") \
-    X(".outmval", &outmval_ptr, \
+    X(".outmval", outmval, \
       FPTYPE_STREAMNAME, 1, \
       FPFLAG_DEFAULT_INPUT \
           | FPFLAG_PRIMARY_CLI_INPUT, \
       "output mode values to DM") \
-    X(".loopgain", &loopgain_ptr, \
+    X(".loopgain", &loopgain, \
       FPTYPE_FLOAT32, 0, \
       FPFLAG_DEFAULT_INPUT \
           | FPFLAG_CLI_INPUT \
           | FPFLAG_WRITERUN, \
       "loop gain") \
-    X(".loopmult", &loopmult_ptr, \
+    X(".loopmult", &loopmult, \
       FPTYPE_FLOAT32, 0, \
       FPFLAG_DEFAULT_INPUT \
           | FPFLAG_CLI_INPUT \
           | FPFLAG_WRITERUN, \
       "loop mult") \
-    X(".looplimit", &looplimit_ptr, \
+    X(".looplimit", &looplimit, \
       FPTYPE_FLOAT32, 0, \
       FPFLAG_DEFAULT_INPUT \
           | FPFLAG_CLI_INPUT \
           | FPFLAG_WRITERUN, \
       "loop limit") \
-    X(".loopZERO", &loopZERO_ptr, \
+    X(".loopZERO", &loopZERO, \
       FPTYPE_ONOFF, 0, \
       FPFLAG_DEFAULT_INPUT \
           | FPFLAG_CLI_INPUT \
           | FPFLAG_WRITERUN, \
       "loop zero") \
-    X(".AOloopindex", &AOloopindex_ptr, \
+    X(".AOloopindex", &AOloopindex, \
       FPTYPE_UINT64, 1, \
       FPFLAG_DEFAULT_INPUT \
           | FPFLAG_PRIMARY_CLI_INPUT, \
       "AO loop index") \
-    X(".loopON", &loopON_ptr, \
+    X(".loopON", &loopON, \
       FPTYPE_ONOFF, 0, \
       FPFLAG_DEFAULT_INPUT \
           | FPFLAG_CLI_INPUT \
           | FPFLAG_WRITERUN, \
       "loop on/off (off=freeze)") \
-    X(".loopNBstep", &loopNBstep_ptr, \
+    X(".loopNBstep", &loopNBstep, \
       FPTYPE_INT64, 0, \
       FPFLAG_DEFAULT_INPUT \
           | FPFLAG_CLI_INPUT \
           | FPFLAG_WRITERUN, \
       "loop nb steps (-1 = inf)") \
-    X(".comp.OLmodes", &compOL_ptr, \
+    X(".comp.OLmodes", &compOL, \
       FPTYPE_ONOFF, 0, \
       FPFLAG_DEFAULT_INPUT | FPFLAG_CLI_INPUT, \
       "compute open loop modes") \
-    X(".comp.WFSfact", &psol_WFSfact_ptr, \
+    X(".comp.WFSfact", &psol_WFSfact, \
       FPTYPE_FLOAT32, 0, \
       FPFLAG_DEFAULT_INPUT | FPFLAG_CLI_INPUT, \
       "ampl correction factor WFS") \
     X(".comp.latencyhardwfr", \
-      &latencyhardwfr_ptr, \
+      &latencyhardwfr, \
       FPTYPE_FLOAT32, 0, \
       FPFLAG_DEFAULT_INPUT | FPFLAG_CLI_INPUT, \
       "hw DM-to-WFS latency [fr]") \
     X(".comp.latencysoftwfr", \
-      &latencysoftwfr_ptr, \
+      &latencysoftwfr, \
       FPTYPE_FLOAT32, 0, \
       FPFLAG_DEFAULT_INPUT | FPFLAG_CLI_INPUT, \
       "sw latency [frame]") \
-    X(".comp.tbuff", &comptbuff_ptr, \
+    X(".comp.tbuff", &comptbuff, \
       FPTYPE_ONOFF, 0, \
       FPFLAG_DEFAULT_INPUT | FPFLAG_CLI_INPUT, \
       "compute telemetry buffers") \
-    X(".comp.autolim", &autolim_ptr, \
+    X(".comp.autolim", &autolim, \
       FPTYPE_ONOFF, 0, \
       FPFLAG_DEFAULT_INPUT | FPFLAG_CLI_INPUT, \
       "automatic modal limits") \
     X(".comp.autolimprobegain", \
-      &autolimprobegain_ptr, \
+      &autolimprobegain, \
       FPTYPE_FLOAT32, 0, \
       FPFLAG_DEFAULT_INPUT | FPFLAG_CLI_INPUT, \
       "sigma measurement gain") \
     X(".comp.autolimsigmafact", \
-      &autolimsigmafact_ptr, \
+      &autolimsigmafact, \
       FPTYPE_FLOAT32, 0, \
       FPFLAG_DEFAULT_INPUT | FPFLAG_CLI_INPUT, \
       "autolimit sigma clip factor") \
-    X(".comp.tbuffsize", &tbuffsize_ptr, \
+    X(".comp.tbuffsize", &tbuffsize, \
       FPTYPE_UINT32, 0, \
       FPFLAG_DEFAULT_INPUT | FPFLAG_CLI_INPUT, \
       "buffer time size") \
     X(".auxDMmval.enable", \
-      &auxDMmvalenable_ptr, \
+      &auxDMmvalenable, \
       FPTYPE_ONOFF, 0, \
       FPFLAG_DEFAULT_INPUT | FPFLAG_CLI_INPUT, \
       "mixing aux DM mode vals") \
     X(".auxDMmval.mixfact", \
-      &auxDMmvalmixfact_ptr, \
+      &auxDMmvalmixfact, \
       FPTYPE_FLOAT32, 0, \
       FPFLAG_DEFAULT_INPUT | FPFLAG_CLI_INPUT, \
       "mixing mult factor") \
     X(".auxDMmval.modulate", \
-      &auxDMmvalmodulate_ptr, \
+      &auxDMmvalmodulate, \
       FPTYPE_ONOFF, 0, \
       FPFLAG_DEFAULT_INPUT | FPFLAG_CLI_INPUT, \
       "modulate auxDM temporally") \
     X(".auxDMmval.modperiod", \
-      &auxDMmvalmodperiod_ptr, \
+      &auxDMmvalmodperiod, \
       FPTYPE_FLOAT32, 0, \
       FPFLAG_DEFAULT_INPUT | FPFLAG_CLI_INPUT, \
       "auxDM mod period [frame]") \
-    X(".PF.enable", &enablePF_ptr, \
+    X(".PF.enable", &enablePF, \
       FPTYPE_ONOFF, 0, \
       FPFLAG_DEFAULT_INPUT | FPFLAG_CLI_INPUT, \
       "enable predictive filter") \
-    X(".PF.NBblock", &PF_NBblock_ptr, \
+    X(".PF.NBblock", &PF_NBblock, \
       FPTYPE_UINT32, 0, \
       FPFLAG_DEFAULT_INPUT | FPFLAG_CLI_INPUT, \
       "nb blocks to wait from") \
-    X(".PF.maxwaitus", &PF_maxwaitus_ptr, \
+    X(".PF.maxwaitus", &PF_maxwaitus, \
       FPTYPE_UINT32, 0, \
       FPFLAG_DEFAULT_INPUT | FPFLAG_CLI_INPUT, \
       "max wait time blks [us]") \
-    X(".PF.mixcoeff", &PFmixcoeff_ptr, \
+    X(".PF.mixcoeff", &PFmixcoeff, \
       FPTYPE_FLOAT32, 0, \
       FPFLAG_DEFAULT_INPUT | FPFLAG_CLI_INPUT, \
       "mixing coeff") \
     X(".autoloop.enable", \
-      &autoloopenable_ptr, \
+      &autoloopenable, \
       FPTYPE_ONOFF, 0, \
       FPFLAG_DEFAULT_INPUT | FPFLAG_CLI_INPUT, \
       "autoloop self-test") \
     X(".autoloop.sleep", \
-      &autoloopsleep_ptr, \
+      &autoloopsleep, \
       FPTYPE_FLOAT32, 0, \
       FPFLAG_DEFAULT_INPUT | FPFLAG_CLI_INPUT, \
       "loop sleep time") \
-    X(".selfRM.enable", &selfRMenable_ptr, \
+    X(".selfRM.enable", &selfRMenable, \
       FPTYPE_ONOFF, 0, \
       FPFLAG_DEFAULT_INPUT | FPFLAG_CLI_INPUT, \
       "start self RM measurement") \
-    X(".selfRM.NBmode", &selfRMnbmode_ptr, \
+    X(".selfRM.NBmode", &selfRMnbmode, \
       FPTYPE_UINT32, 0, \
       FPFLAG_DEFAULT_INPUT | FPFLAG_CLI_INPUT, \
       "number of mode poked") \
     X(".selfRM.pokeampl", \
-      &selfRMpokeampl_ptr, \
+      &selfRMpokeampl, \
       FPTYPE_FLOAT32, 0, \
       FPFLAG_DEFAULT_INPUT | FPFLAG_CLI_INPUT, \
       "poke amplitude") \
-    X(".selfRM.zsize", &selfRMzsize_ptr, \
+    X(".selfRM.zsize", &selfRMzsize, \
       FPTYPE_UINT32, 0, \
       FPFLAG_DEFAULT_INPUT | FPFLAG_CLI_INPUT, \
       "nb time steps recorded") \
-    X(".selfRM.nbiter", &selfRMnbiter_ptr, \
+    X(".selfRM.nbiter", &selfRMnbiter, \
       FPTYPE_UINT32, 0, \
       FPFLAG_DEFAULT_INPUT | FPFLAG_CLI_INPUT, \
       "nb iterations averaged") \
     X(".selfRM.nbsettle", \
-      &selfRMnbsettlestep_ptr, \
+      &selfRMnbsettlestep, \
       FPTYPE_UINT32, 0, \
       FPFLAG_DEFAULT_INPUT | FPFLAG_CLI_INPUT, \
       "nb loop iter to settle") \
-    X(".testOL.enable", &testOL_ptr, \
+    X(".testOL.enable", &testOL, \
       FPTYPE_ONOFF, 0, \
       FPFLAG_DEFAULT_INPUT | FPFLAG_CLI_INPUT, \
       "OL reconstruction test") \
-    X(".testOL.loop", &testOLloop_ptr, \
+    X(".testOL.loop", &testOLloop, \
       FPTYPE_ONOFF, 0, \
       FPFLAG_DEFAULT_INPUT | FPFLAG_CLI_INPUT, \
       "run inloop") \
     X(".testOL.updategain", \
-      &testOLupdategain_ptr, \
+      &testOLupdategain, \
       FPTYPE_FLOAT32, 0, \
       FPFLAG_DEFAULT_INPUT | FPFLAG_CLI_INPUT, \
       "update gain") \
-    X(".testOL.mode", &testOLmode_ptr, \
+    X(".testOL.mode", &testOLmode, \
       FPTYPE_UINT32, 0, \
       FPFLAG_DEFAULT_INPUT | FPFLAG_CLI_INPUT, \
       "mode index") \
-    X(".testOL.ampl", &testOLampl_ptr, \
+    X(".testOL.ampl", &testOLampl, \
       FPTYPE_FLOAT32, 0, \
       FPFLAG_DEFAULT_INPUT | FPFLAG_CLI_INPUT, \
       "amplitude") \
     X(".testOL.nbsample", \
-      &testOLnbsample_ptr, \
+      &testOLnbsample, \
       FPTYPE_UINT32, 0, \
       FPFLAG_DEFAULT_INPUT | FPFLAG_CLI_INPUT, \
       "number of samples") \
-    X(".testOL.cnt", &testOLcnt_ptr, \
+    X(".testOL.cnt", &testOLcnt, \
       FPTYPE_UINT32, 0, \
       FPFLAG_DEFAULT_INPUT | FPFLAG_CLI_INPUT, \
       "samples count") \
-    X(".offload.enable", &offload_ptr, \
+    X(".offload.enable", &offload, \
       FPTYPE_ONOFF, 0, \
       FPFLAG_DEFAULT_INPUT | FPFLAG_CLI_INPUT, \
       "offload output ON/OFF") \
     X(".offload.loopgain", \
-      &offloadloopgain_ptr, \
+      &offloadloopgain, \
       FPTYPE_FLOAT32, 0, \
       FPFLAG_DEFAULT_INPUT | FPFLAG_CLI_INPUT, \
       "offload loop gain") \
     X(".offload.loopmult", \
-      &offloadloopmult_ptr, \
+      &offloadloopmult, \
       FPTYPE_FLOAT32, 0, \
       FPFLAG_DEFAULT_INPUT | FPFLAG_CLI_INPUT, \
       "offload loop mult") \
     X(".offload.looplimit", \
-      &offloadlooplimit_ptr, \
+      &offloadlooplimit, \
       FPTYPE_FLOAT32, 0, \
       FPFLAG_DEFAULT_INPUT | FPFLAG_CLI_INPUT, \
       "offload loop limit") \
-    X(".rec.enable", &recburst_ptr, \
+    X(".rec.enable", &recburst, \
       FPTYPE_ONOFF, 0, \
       FPFLAG_DEFAULT_INPUT | FPFLAG_CLI_INPUT, \
       "telemetry burt write") \
-    X(".rec.mode", &recburst_mode_ptr, \
+    X(".rec.mode", &recburst_mode, \
       FPTYPE_UINT32, 0, \
       FPFLAG_DEFAULT_INPUT | FPFLAG_CLI_INPUT, \
       "mode index") \
     X(".rec.nbstep", \
-      &recburst_nbsample_ptr, \
+      &recburst_nbsample, \
       FPTYPE_UINT32, 0, \
       FPFLAG_DEFAULT_INPUT | FPFLAG_CLI_INPUT, \
       "number of steps recorded")
@@ -759,7 +759,7 @@ FPS_V2_SECTION5(FPS_PARAMS)
 static errno_t compute_function()
 {
     IMGID imginWFS =
-        imgid_make_from_name(inmval_ptr);
+        imgid_make_from_name(inmval);
     resolveIMGID(&imginWFS, ERRMODE_ABORT,
         data.core.image, data.core.NB_MAX_IMAGE);
 
@@ -767,7 +767,7 @@ static errno_t compute_function()
 
     IMGID imgout =
         stream_connect_create_2Df32(
-            outmval_ptr, NBmode, 1);
+            outmval, NBmode, 1);
 
     MFILT_STATE *state =
         modal_filter_init(NBmode);

--- a/AOloopControl_DM/AOloopControl_DM_comb.c
+++ b/AOloopControl_DM/AOloopControl_DM_comb.c
@@ -41,52 +41,52 @@ static FPS_APP_INFO FPS_app_info = {
  * 2.  LOCAL PARAMETER VARIABLES
  * ============================================================= */
 
-static uint32_t *DMindex_ptr          = NULL;
-static char     *DMcombout_ptr        = NULL;
-static uint32_t *DMxsize_ptr          = NULL;
-static uint32_t *DMysize_ptr          = NULL;
-static uint32_t *NBchannel_ptr        = NULL;
-static uint32_t *DMmode_ptr           = NULL;
-static uint32_t *AveMode_ptr          = NULL;
-static uint64_t *dm2dm_mode_ptr       = NULL;
-static char     *dm2dm_DMmodes_ptr    = NULL;
-static char     *dm2dm_outdisp_ptr    = NULL;
-static uint64_t *wfsrefmode_ptr       = NULL;
-static char     *wfsref_WFSRespMat_ptr = NULL;
-static char     *wfsref_out_ptr       = NULL;
-static uint64_t *voltmode_ptr         = NULL;
-static uint32_t *volttype_ptr         = NULL;
-static float    *stroke100_ptr        = NULL;
-static char     *voltname_ptr         = NULL;
-static char     *outv_ftype_ptr       = NULL;
-static float    *outv_exp_ptr         = NULL;
-static float    *outv_inrange_min_ptr = NULL;
-static float    *outv_inrange_max_ptr = NULL;
-static float    *outv_outrange_min_ptr = NULL;
-static float    *outv_outrange_max_ptr = NULL;
-static float    *DClevel_ptr          = NULL;
-static float    *maxvolt_ptr          = NULL;
-static uint64_t *loopcnt_ptr          = NULL;
-static uint64_t *astrogrid_ptr        = NULL;
-static uint32_t *astrogridchan_ptr    = NULL;
-static char     *astrogridsname_ptr   = NULL;
-static float    *astrogridmult_ptr    = NULL;
-static uint32_t *astrogridtdelay_ptr  = NULL;
-static uint32_t *astrogridNBframe_ptr = NULL;
-static uint64_t *zpoffsetenable_ptr   = NULL;
-static char     *DMcomboutzpo_ptr     = NULL;
-static uint64_t *zpoffsetch00_ptr     = NULL;
-static uint64_t *zpoffsetch01_ptr     = NULL;
-static uint64_t *zpoffsetch02_ptr     = NULL;
-static uint64_t *zpoffsetch03_ptr     = NULL;
-static uint64_t *zpoffsetch04_ptr     = NULL;
-static uint64_t *zpoffsetch05_ptr     = NULL;
-static uint64_t *zpoffsetch06_ptr     = NULL;
-static uint64_t *zpoffsetch07_ptr     = NULL;
-static uint64_t *zpoffsetch08_ptr     = NULL;
-static uint64_t *zpoffsetch09_ptr     = NULL;
-static uint64_t *zpoffsetch10_ptr     = NULL;
-static uint64_t *zpoffsetch11_ptr     = NULL;
+static uint32_t DMindex = 0;
+static char DMcombout[FUNCTION_PARAMETER_STRMAXLEN] = "";
+static uint32_t DMxsize = 0;
+static uint32_t DMysize = 0;
+static uint32_t NBchannel = 0;
+static uint32_t DMmode = 0;
+static uint32_t AveMode = 0;
+static uint64_t dm2dm_mode = 0;
+static char dm2dm_DMmodes[FUNCTION_PARAMETER_STRMAXLEN] = "";
+static char dm2dm_outdisp[FUNCTION_PARAMETER_STRMAXLEN] = "";
+static uint64_t wfsrefmode = 0;
+static char wfsref_WFSRespMat[FUNCTION_PARAMETER_STRMAXLEN] = "";
+static char wfsref_out[FUNCTION_PARAMETER_STRMAXLEN] = "";
+static uint64_t voltmode = 0;
+static uint32_t volttype = 0;
+static float stroke100 = 0;
+static char voltname[FUNCTION_PARAMETER_STRMAXLEN] = "";
+static char outv_ftype[FUNCTION_PARAMETER_STRMAXLEN] = "";
+static float outv_exp = 0;
+static float outv_inrange_min = 0;
+static float outv_inrange_max = 0;
+static float outv_outrange_min = 0;
+static float outv_outrange_max = 0;
+static float DClevel = 0;
+static float maxvolt = 0;
+static uint64_t loopcnt = 0;
+static uint64_t astrogrid = 0;
+static uint32_t astrogridchan = 0;
+static char astrogridsname[FUNCTION_PARAMETER_STRMAXLEN] = "";
+static float astrogridmult = 0;
+static uint32_t astrogridtdelay = 0;
+static uint32_t astrogridNBframe = 0;
+static uint64_t zpoffsetenable = 0;
+static char DMcomboutzpo[FUNCTION_PARAMETER_STRMAXLEN] = "";
+static uint64_t zpoffsetch00 = 0;
+static uint64_t zpoffsetch01 = 0;
+static uint64_t zpoffsetch02 = 0;
+static uint64_t zpoffsetch03 = 0;
+static uint64_t zpoffsetch04 = 0;
+static uint64_t zpoffsetch05 = 0;
+static uint64_t zpoffsetch06 = 0;
+static uint64_t zpoffsetch07 = 0;
+static uint64_t zpoffsetch08 = 0;
+static uint64_t zpoffsetch09 = 0;
+static uint64_t zpoffsetch10 = 0;
+static uint64_t zpoffsetch11 = 0;
 
 static uint64_t processinfo_change_cnt_local = 0;
 
@@ -125,25 +125,25 @@ static errno_t DMdisp_add_disp_from_circular_buffer(DMCOMB_STATE *state)
     if(state->DMdisp_add_disp_from_circular_buffer_init == 0)
     {
         printf("(re-)initializing DMdisp_add_disp_from_circular_buffer");
-        delete_image_ID(astrogridsname_ptr, DELETE_IMAGE_ERRMODE_WARNING);
-        read_sharedmem_image(astrogridsname_ptr,
+        delete_image_ID(astrogridsname, DELETE_IMAGE_ERRMODE_WARNING);
+        read_sharedmem_image(astrogridsname,
             data.core.image,
             data.core.NB_MAX_IMAGE);
-        state->ag_imgdispbuffer = imgid_make_from_name(astrogridsname_ptr);
+        state->ag_imgdispbuffer = imgid_make_from_name(astrogridsname);
         resolveIMGID(&state->ag_imgdispbuffer,
             ERRMODE_ABORT,
             data.core.image,
             data.core.NB_MAX_IMAGE);
-        state->ag_xysize = (uint64_t)(*DMxsize_ptr) * (*DMysize_ptr);
+        state->ag_xysize = (uint64_t)(DMxsize) * (DMysize);
         state->ag_sliceindex = 0;
         state->ag_framecnt = 0;
         state->DMdisp_add_disp_from_circular_buffer_init = 1;
     }
 
-    if((*astrogrid_ptr) & FPFLAG_ONOFF)
+    if((astrogrid) & FPFLAG_ONOFF)
     {
         state->ag_framecnt++;
-        if(state->ag_framecnt >= (*astrogridNBframe_ptr))
+        if(state->ag_framecnt >= (astrogridNBframe))
         {
             state->ag_framecnt = 0;
             state->ag_sliceindex++;
@@ -153,12 +153,12 @@ static errno_t DMdisp_add_disp_from_circular_buffer(DMCOMB_STATE *state)
                 state->ag_sliceindex = 0;
             }
 
-            uint32_t chan = *astrogridchan_ptr;
-            if (chan < *NBchannel_ptr) {
+            uint32_t chan = astrogridchan;
+            if (chan < NBchannel) {
                 float * MILK_RESTRICT outptr = MILK_ASSUME_ALIGNED(state->imgch[chan].im->array.F);
                 const float * MILK_RESTRICT inptr = MILK_ASSUME_ALIGNED(state->ag_imgdispbuffer.im->array.F);
                 uint64_t offset = state->ag_sliceindex * state->ag_xysize;
-                float mult = *astrogridmult_ptr;
+                float mult = astrogridmult;
                 
                 #pragma omp simd
                 for(uint64_t ii = 0; ii < state->ag_xysize; ii++)
@@ -186,45 +186,45 @@ static errno_t DM_displ2V(
     DMCOMB_STATE *state)
 {
     uint64_t xysize =
-        (uint64_t)(*DMxsize_ptr)
-        * (*DMysize_ptr);
+        (uint64_t)(DMxsize)
+        * (DMysize);
     double *valarray = state->valarray;
 
-    if((*volttype_ptr) == 1)
+    if((volttype) == 1)
     {
         float inrange =
-            (*maxvolt_ptr)
-            * (*stroke100_ptr) / 100.0f;
-        strcpy(outv_ftype_ptr, "float32");
-        *outv_exp_ptr = 1.0f;
-        *outv_inrange_min_ptr = -inrange;
-        *outv_inrange_max_ptr = inrange;
-        *outv_outrange_min_ptr =
-            -(*maxvolt_ptr);
-        *outv_outrange_max_ptr =
-            -(*maxvolt_ptr);
+            (maxvolt)
+            * (stroke100) / 100.0f;
+        strcpy(outv_ftype, "float32");
+        outv_exp = 1.0f;
+        outv_inrange_min = -inrange;
+        outv_inrange_max = inrange;
+        outv_outrange_min =
+            -(maxvolt);
+        outv_outrange_max =
+            -(maxvolt);
     }
-    else if((*volttype_ptr) == 2)
+    else if((volttype) == 2)
     {
         float inrange =
-            (*maxvolt_ptr)
-            * (*stroke100_ptr) / 100.0f;
-        strcpy(outv_ftype_ptr, "uint16");
-        *outv_exp_ptr = 0.5f;
-        *outv_inrange_min_ptr = -inrange;
-        *outv_inrange_max_ptr = inrange;
-        *outv_outrange_min_ptr = 0.0f;
-        *outv_outrange_max_ptr =
-            (*maxvolt_ptr)
+            (maxvolt)
+            * (stroke100) / 100.0f;
+        strcpy(outv_ftype, "uint16");
+        outv_exp = 0.5f;
+        outv_inrange_min = -inrange;
+        outv_inrange_max = inrange;
+        outv_outrange_min = 0.0f;
+        outv_outrange_max =
+            (maxvolt)
             / 300.0f * 16384.0f;
     }
 
     {
-        float exp_val = *outv_exp_ptr;
-        float inmin = *outv_inrange_min_ptr;
-        float inmax = *outv_inrange_max_ptr;
-        float outmin = *outv_outrange_min_ptr;
-        float outmax = *outv_outrange_max_ptr;
+        float exp_val = outv_exp;
+        float inmin = outv_inrange_min;
+        float inmax = outv_inrange_max;
+        float outmin = outv_outrange_min;
+        float outmax = outv_outrange_max;
         float range = inmax - inmin;
         float inv_range =
             (range != 0.0f)
@@ -285,11 +285,11 @@ static errno_t DM_displ2V(
         }
     }
 
-    if((*volttype_ptr) == 1)
+    if((volttype) == 1)
     {
         float scale =
-            100.0f / (*stroke100_ptr);
-        float maxv = *maxvolt_ptr;
+            100.0f / (stroke100);
+        float maxv = maxvolt;
         for(uint64_t ii = 0;
             ii < xysize; ii++)
         {
@@ -301,10 +301,10 @@ static errno_t DM_displ2V(
             imgvolt.im->array.F[ii] = v;
         }
     }
-    else if((*volttype_ptr) == 2)
+    else if((volttype) == 2)
     {
-        float inv_s = 1.0f / (*stroke100_ptr);
-        float maxv = *maxvolt_ptr;
+        float inv_s = 1.0f / (stroke100);
+        float maxv = maxvolt;
         float vscale =
             16384.0f / 300.0f;
         for(uint64_t ii = 0;
@@ -322,10 +322,10 @@ static errno_t DM_displ2V(
                 (volt * vscale);
         }
     }
-    else if((*volttype_ptr) == 3)
+    else if((volttype) == 3)
     {
-        float inv_s = 1.0f / (*stroke100_ptr);
-        float maxv = *maxvolt_ptr;
+        float inv_s = 1.0f / (stroke100);
+        float maxv = maxvolt;
         for(uint64_t ii = 0;
             ii < xysize; ii++)
         {
@@ -343,10 +343,10 @@ static errno_t DM_displ2V(
                 (volt * 65535.0f);
         }
     }
-    else if((*volttype_ptr) == 0)
+    else if((volttype) == 0)
     {
         if(strcmp(
-               outv_ftype_ptr,
+               outv_ftype,
                "float64") == 0)
         {
             for(uint64_t ii = 0;
@@ -355,7 +355,7 @@ static errno_t DM_displ2V(
                     valarray[ii];
         }
         else if(strcmp(
-                    outv_ftype_ptr,
+                    outv_ftype,
                     "uint16") == 0)
         {
             for(uint64_t ii = 0;
@@ -364,7 +364,7 @@ static errno_t DM_displ2V(
                     (uint16_t)(valarray[ii]);
         }
         else if(strcmp(
-                    outv_ftype_ptr,
+                    outv_ftype,
                     "uint32") == 0)
         {
             for(uint64_t ii = 0;
@@ -373,7 +373,7 @@ static errno_t DM_displ2V(
                     (uint32_t)(valarray[ii]);
         }
         else if(strcmp(
-                    outv_ftype_ptr,
+                    outv_ftype,
                     "uint64") == 0)
         {
             for(uint64_t ii = 0;
@@ -382,7 +382,7 @@ static errno_t DM_displ2V(
                     (uint64_t)(valarray[ii]);
         }
         else if(strcmp(
-                    outv_ftype_ptr,
+                    outv_ftype,
                     "int16") == 0)
         {
             for(uint64_t ii = 0;
@@ -391,7 +391,7 @@ static errno_t DM_displ2V(
                     (int16_t)(valarray[ii]);
         }
         else if(strcmp(
-                    outv_ftype_ptr,
+                    outv_ftype,
                     "int32") == 0)
         {
             for(uint64_t ii = 0;
@@ -400,7 +400,7 @@ static errno_t DM_displ2V(
                     (int32_t)(valarray[ii]);
         }
         else if(strcmp(
-                    outv_ftype_ptr,
+                    outv_ftype,
                     "int64") == 0)
         {
             for(uint64_t ii = 0;
@@ -427,10 +427,10 @@ static errno_t update_dmdisp(
     float *dmdisptmp
 )
 {
-    uint64_t size = (uint64_t)(*DMxsize_ptr) * (*DMysize_ptr);
+    uint64_t size = (uint64_t)(DMxsize) * (DMysize);
     memcpy(dmdisptmp, imgch[0].im->array.F, sizeof(float) * size);
 
-    for(uint32_t ch = 1; ch < *NBchannel_ptr; ch++)
+    for(uint32_t ch = 1; ch < NBchannel; ch++)
     {
         const float * MILK_RESTRICT inptr = MILK_ASSUME_ALIGNED(imgch[ch].im->array.F);
         #pragma omp simd
@@ -441,14 +441,14 @@ static errno_t update_dmdisp(
     }
 
     double ave = 0.0;
-    if(*AveMode_ptr == 1)
+    if(AveMode == 1)
     {
         for(uint_fast64_t ii = 0; ii < size; ii++) ave += dmdisptmp[ii];
         ave /= size;
         for(uint_fast64_t ii = 0; ii < size; ii++)
         {
-            dmdisptmp[ii] += (*DClevel_ptr - ave);
-            if((*voltmode_ptr) & FPFLAG_ONOFF) {
+            dmdisptmp[ii] += (DClevel - ave);
+            if((voltmode) & FPFLAG_ONOFF) {
                 if(dmdisptmp[ii] < 0.0) dmdisptmp[ii] = 0.0;
             }
         }
@@ -465,10 +465,10 @@ static errno_t update_dmdispzpo(
     int *zpoffset_channel
 )
 {
-    uint64_t size = (uint64_t)(*DMxsize_ptr) * (*DMysize_ptr);
+    uint64_t size = (uint64_t)(DMxsize) * (DMysize);
     memset(dmdisptmp, 0, sizeof(float) * size);
 
-    for(uint32_t ch = 0; ch < *NBchannel_ptr; ch++)
+    for(uint32_t ch = 0; ch < NBchannel; ch++)
     {
         if(zpoffset_channel[ch] == 1)
         {
@@ -515,10 +515,10 @@ static DMCOMB_STATE* dmcomb_init()
         fflush(stdout);
     }
 
-    state->imgch = calloc(*NBchannel_ptr, sizeof(IMGID));
-    for(uint32_t ch = 0; ch < *NBchannel_ptr; ch++) {
+    state->imgch = calloc(NBchannel, sizeof(IMGID));
+    for(uint32_t ch = 0; ch < NBchannel; ch++) {
         char name[STRINGMAXLEN_STREAMNAME];
-        snprintf(name, sizeof(name), "dm%02udisp%02u", *DMindex_ptr, ch);
+        snprintf(name, sizeof(name), "dm%02udisp%02u", DMindex, ch);
 
         if (UNLIKELY(data.core.Debug > 0)) {
             printf("DEBUG: channel %d : %s\n", ch, name);
@@ -534,8 +534,8 @@ static DMCOMB_STATE* dmcomb_init()
         }
 
         state->imgch[ch] = stream_connect_create_2Df32(name,
-            *DMxsize_ptr,
-            *DMysize_ptr);
+            DMxsize,
+            DMysize);
     }
 
     if (UNLIKELY(data.core.Debug > 0)) {
@@ -543,12 +543,12 @@ static DMCOMB_STATE* dmcomb_init()
         fflush(stdout);
     }
 
-    state->imgdisp = stream_connect_create_2Df32(DMcombout_ptr,
-        *DMxsize_ptr,
-        *DMysize_ptr);
-    state->imgdispzpo = stream_connect_create_2Df32(DMcomboutzpo_ptr,
-        *DMxsize_ptr,
-        *DMysize_ptr);
+    state->imgdisp = stream_connect_create_2Df32(DMcombout,
+        DMxsize,
+        DMysize);
+    state->imgdispzpo = stream_connect_create_2Df32(DMcomboutzpo,
+        DMxsize,
+        DMysize);
 
     if (UNLIKELY(data.core.Debug > 0)) {
         printf("DEBUG  %s [%d] %s\n", __FILE__, __LINE__, __FUNCTION__);
@@ -557,22 +557,22 @@ static DMCOMB_STATE* dmcomb_init()
 
     state->dmdisptmp = malloc(
         sizeof(float)
-        * (*DMxsize_ptr) * (*DMysize_ptr));
+        * (DMxsize) * (DMysize));
     state->valarray = malloc(
         sizeof(double)
-        * (*DMxsize_ptr) * (*DMysize_ptr));
+        * (DMxsize) * (DMysize));
 
     if (UNLIKELY(data.core.Debug > 0)) {
         printf("DEBUG  %s [%d] %s\n", __FILE__, __LINE__, __FUNCTION__);
         fflush(stdout);
     }
 
-    if((*voltmode_ptr) & FPFLAG_ONOFF) {
+    if((voltmode) & FPFLAG_ONOFF) {
         if(
-            image_ID(voltname_ptr, data.core.image, data.core.NB_MAX_IMAGE) == -1) read_sharedmem_image(voltname_ptr,
+            image_ID(voltname, data.core.image, data.core.NB_MAX_IMAGE) == -1) read_sharedmem_image(voltname,
             data.core.image,
             data.core.NB_MAX_IMAGE);
-        state->imgdmvolt = imgid_make_from_name(voltname_ptr);
+        state->imgdmvolt = imgid_make_from_name(voltname);
         resolveIMGID(&state->imgdmvolt,
             ERRMODE_ABORT,
             data.core.image,
@@ -608,18 +608,18 @@ static void dmcomb_step(
     }
 
     // Update ZPO channels state
-    state->zpoffset_channel[0]  = ((*zpoffsetch00_ptr) & FPFLAG_ONOFF) ? 1 : 0;
-    state->zpoffset_channel[1]  = ((*zpoffsetch01_ptr) & FPFLAG_ONOFF) ? 1 : 0;
-    state->zpoffset_channel[2]  = ((*zpoffsetch02_ptr) & FPFLAG_ONOFF) ? 1 : 0;
-    state->zpoffset_channel[3]  = ((*zpoffsetch03_ptr) & FPFLAG_ONOFF) ? 1 : 0;
-    state->zpoffset_channel[4]  = ((*zpoffsetch04_ptr) & FPFLAG_ONOFF) ? 1 : 0;
-    state->zpoffset_channel[5]  = ((*zpoffsetch05_ptr) & FPFLAG_ONOFF) ? 1 : 0;
-    state->zpoffset_channel[6]  = ((*zpoffsetch06_ptr) & FPFLAG_ONOFF) ? 1 : 0;
-    state->zpoffset_channel[7]  = ((*zpoffsetch07_ptr) & FPFLAG_ONOFF) ? 1 : 0;
-    state->zpoffset_channel[8]  = ((*zpoffsetch08_ptr) & FPFLAG_ONOFF) ? 1 : 0;
-    state->zpoffset_channel[9]  = ((*zpoffsetch09_ptr) & FPFLAG_ONOFF) ? 1 : 0;
-    state->zpoffset_channel[10] = ((*zpoffsetch10_ptr) & FPFLAG_ONOFF) ? 1 : 0;
-    state->zpoffset_channel[11] = ((*zpoffsetch11_ptr) & FPFLAG_ONOFF) ? 1 : 0;
+    state->zpoffset_channel[0]  = ((zpoffsetch00) & FPFLAG_ONOFF) ? 1 : 0;
+    state->zpoffset_channel[1]  = ((zpoffsetch01) & FPFLAG_ONOFF) ? 1 : 0;
+    state->zpoffset_channel[2]  = ((zpoffsetch02) & FPFLAG_ONOFF) ? 1 : 0;
+    state->zpoffset_channel[3]  = ((zpoffsetch03) & FPFLAG_ONOFF) ? 1 : 0;
+    state->zpoffset_channel[4]  = ((zpoffsetch04) & FPFLAG_ONOFF) ? 1 : 0;
+    state->zpoffset_channel[5]  = ((zpoffsetch05) & FPFLAG_ONOFF) ? 1 : 0;
+    state->zpoffset_channel[6]  = ((zpoffsetch06) & FPFLAG_ONOFF) ? 1 : 0;
+    state->zpoffset_channel[7]  = ((zpoffsetch07) & FPFLAG_ONOFF) ? 1 : 0;
+    state->zpoffset_channel[8]  = ((zpoffsetch08) & FPFLAG_ONOFF) ? 1 : 0;
+    state->zpoffset_channel[9]  = ((zpoffsetch09) & FPFLAG_ONOFF) ? 1 : 0;
+    state->zpoffset_channel[10] = ((zpoffsetch10) & FPFLAG_ONOFF) ? 1 : 0;
+    state->zpoffset_channel[11] = ((zpoffsetch11) & FPFLAG_ONOFF) ? 1 : 0;
 
     int zpooffsetchange = 0;
     state->zpochecksum = 0;
@@ -634,19 +634,19 @@ static void dmcomb_step(
     long cnt0sum = 0;
     long cnt0sumzpo = 0;
 
-    if((*astrogrid_ptr) & FPFLAG_ONOFF) {
-        for(uint32_t ch = 0; ch < *NBchannel_ptr; ch++) {
-            if(ch != *astrogridchan_ptr) {
+    if((astrogrid) & FPFLAG_ONOFF) {
+        for(uint32_t ch = 0; ch < NBchannel; ch++) {
+            if(ch != astrogridchan) {
                 cnt0sum += state->imgch[ch].md->cnt0;
-                if(((*zpoffsetenable_ptr) & FPFLAG_ONOFF) && state->zpoffset_channel[ch]) {
+                if(((zpoffsetenable) & FPFLAG_ONOFF) && state->zpoffset_channel[ch]) {
                     cnt0sumzpo += state->imgch[ch].md->cnt0;
                 }
             }
         }
     } else {
-        for(uint32_t ch = 0; ch < *NBchannel_ptr; ch++) {
+        for(uint32_t ch = 0; ch < NBchannel; ch++) {
             cnt0sum += state->imgch[ch].md->cnt0;
-            if(((*zpoffsetenable_ptr) & FPFLAG_ONOFF) && state->zpoffset_channel[ch]) {
+            if(((zpoffsetenable) & FPFLAG_ONOFF) && state->zpoffset_channel[ch]) {
                 cnt0sumzpo += state->imgch[ch].md->cnt0;
             }
         }
@@ -660,22 +660,22 @@ static void dmcomb_step(
         state->cntsumrefzpo = cnt0sumzpo;
         DMupdatezpo = 1;
     }
-    if(((*zpoffsetenable_ptr) & FPFLAG_ONOFF) && zpooffsetchange) DMupdatezpo = 1;
+    if(((zpoffsetenable) & FPFLAG_ONOFF) && zpooffsetchange) DMupdatezpo = 1;
 
     if(LIKELY(DMupdate)) {
-        if(!((*astrogrid_ptr) & FPFLAG_ONOFF)) state->DMdisp_add_disp_from_circular_buffer_init = 0;
+        if(!((astrogrid) & FPFLAG_ONOFF)) state->DMdisp_add_disp_from_circular_buffer_init = 0;
 
-        if(((*astrogrid_ptr) & FPFLAG_ONOFF) && (*astrogridtdelay_ptr == 0)) {
+        if(((astrogrid) & FPFLAG_ONOFF) && (astrogridtdelay == 0)) {
             DMdisp_add_disp_from_circular_buffer(state);
             processinfo_update_output_stream(processinfo,
-                state->imgch[*astrogridchan_ptr].im,
+                state->imgch[astrogridchan].im,
                 NULL);
         }
 
         update_dmdisp(state->imgdisp, state->imgch, state->dmdisptmp);
         processinfo_update_output_stream(processinfo, state->imgdisp.im, NULL);
 
-        if((*voltmode_ptr) & FPFLAG_ONOFF) {
+        if((voltmode) & FPFLAG_ONOFF) {
             state->imgdmvolt.md->write = 1;
             DM_displ2V(state->imgdisp, state->imgdmvolt, state);
             processinfo_update_output_stream(processinfo,
@@ -683,8 +683,8 @@ static void dmcomb_step(
                 NULL);
         }
 
-        if(((*astrogrid_ptr) & FPFLAG_ONOFF) && (*astrogridtdelay_ptr != 0)) {
-            long nsec = (long)(1000 * (*astrogridtdelay_ptr));
+        if(((astrogrid) & FPFLAG_ONOFF) && (astrogridtdelay != 0)) {
+            long nsec = (long)(1000 * (astrogridtdelay));
             struct timespec timesleep;
             timesleep.tv_sec = nsec / 1000000000;
             timesleep.tv_nsec = nsec % 1000000000;
@@ -692,7 +692,7 @@ static void dmcomb_step(
 
             DMdisp_add_disp_from_circular_buffer(state);
             processinfo_update_output_stream(processinfo,
-                state->imgch[*astrogridchan_ptr].im,
+                state->imgch[astrogridchan].im,
                 NULL);
 
             update_dmdisp(state->imgdisp, state->imgch, state->dmdisptmp);
@@ -700,7 +700,7 @@ static void dmcomb_step(
                 state->imgdisp.im,
                 NULL);
 
-            if((*voltmode_ptr) & FPFLAG_ONOFF) {
+            if((voltmode) & FPFLAG_ONOFF) {
                 state->imgdmvolt.md->write = 1;
                 DM_displ2V(state->imgdisp, state->imgdmvolt, state);
                 processinfo_update_output_stream(processinfo,
@@ -723,7 +723,7 @@ static void dmcomb_step(
 
 static void dmcomb_validate() __attribute__((unused));
 static void dmcomb_validate() {
-    if (DMindex_ptr && *DMindex_ptr > 99) *DMindex_ptr = 99;
+    if (DMindex > 99) DMindex = 99;
 }
 
 
@@ -732,228 +732,228 @@ static void dmcomb_validate() {
  * ============================================================= */
 
 #define FPS_PARAMS(X) \
-    X(".DMindex", &DMindex_ptr, \
+    X(".DMindex", &DMindex, \
       FPTYPE_UINT32, 1, \
       FPFLAG_DEFAULT_INPUT \
           | FPFLAG_MINLIMIT \
           | FPFLAG_MAXLIMIT, \
       "DM index") \
-    X(".DMcombout", &DMcombout_ptr, \
+    X(".DMcombout", DMcombout, \
       FPTYPE_STREAMNAME, 1, \
       FPFLAG_DEFAULT_INPUT, \
       "output combined cmd stream") \
-    X(".DMxsize", &DMxsize_ptr, \
+    X(".DMxsize", &DMxsize, \
       FPTYPE_UINT32, 0, \
       FPFLAG_DEFAULT_INPUT, \
       "x size") \
-    X(".DMysize", &DMysize_ptr, \
+    X(".DMysize", &DMysize, \
       FPTYPE_UINT32, 0, \
       FPFLAG_DEFAULT_INPUT, \
       "y size") \
-    X(".NBchannel", &NBchannel_ptr, \
+    X(".NBchannel", &NBchannel, \
       FPTYPE_UINT32, 0, \
       FPFLAG_DEFAULT_INPUT, \
       "number of DM channels") \
-    X(".DMmode", &DMmode_ptr, \
+    X(".DMmode", &DMmode, \
       FPTYPE_UINT32, 0, \
       FPFLAG_DEFAULT_INPUT, \
       "0:SquareGrid 1:Generic") \
-    X(".AveMode", &AveMode_ptr, \
+    X(".AveMode", &AveMode, \
       FPTYPE_UINT32, 0, \
       FPFLAG_DEFAULT_INPUT, \
       "Piston (mean) subtract") \
     X(".option.dm2dm_mode", \
-      &dm2dm_mode_ptr, \
+      &dm2dm_mode, \
       FPTYPE_ONOFF, 0, \
       FPFLAG_DEFAULT_INPUT, \
       "DM to DM offset mode") \
     X(".option.dm2dm_DMmodes", \
-      &dm2dm_DMmodes_ptr, \
+      dm2dm_DMmodes, \
       FPTYPE_STREAMNAME, 0, \
       FPFLAG_DEFAULT_INPUT, \
       "output stream DM to DM") \
     X(".option.dm2dm_outdisp", \
-      &dm2dm_outdisp_ptr, \
+      dm2dm_outdisp, \
       FPTYPE_STREAMNAME, 0, \
       FPFLAG_DEFAULT_INPUT, \
       "DM output data stream") \
     X(".option.wfsrefmode", \
-      &wfsrefmode_ptr, \
+      &wfsrefmode, \
       FPTYPE_ONOFF, 0, \
       FPFLAG_DEFAULT_INPUT, \
       "WFS ref mode") \
     X(".option.wfsref_WFSRespMat", \
-      &wfsref_WFSRespMat_ptr, \
+      wfsref_WFSRespMat, \
       FPTYPE_STREAMNAME, 0, \
       FPFLAG_DEFAULT_INPUT, \
       "Output WFS resp matrix") \
     X(".option.wfsref_out", \
-      &wfsref_out_ptr, \
+      wfsref_out, \
       FPTYPE_STREAMNAME, 0, \
       FPFLAG_DEFAULT_INPUT, \
       "Output WFS") \
     X(".option.voltmode", \
-      &voltmode_ptr, \
+      &voltmode, \
       FPTYPE_ONOFF, 0, \
       FPFLAG_DEFAULT_INPUT, \
       "Volt mode") \
     X(".option.volttype", \
-      &volttype_ptr, \
+      &volttype, \
       FPTYPE_UINT32, 0, \
       FPFLAG_DEFAULT_INPUT, \
       "volt type") \
     X(".option.stroke100", \
-      &stroke100_ptr, \
+      &stroke100, \
       FPTYPE_FLOAT32, 0, \
       FPFLAG_DEFAULT_INPUT, \
       "Stroke for 100V [um]") \
     X(".option.voltname", \
-      &voltname_ptr, \
+      voltname, \
       FPTYPE_STREAMNAME, 0, \
       FPFLAG_DEFAULT_INPUT, \
       "Stream name volt output") \
     X(".option.outv_ftype", \
-      &outv_ftype_ptr, \
+      outv_ftype, \
       FPTYPE_STRING, 0, \
       FPFLAG_DEFAULT_INPUT, \
       "output volt type") \
     X(".option.outv_exp", \
-      &outv_exp_ptr, \
+      &outv_exp, \
       FPTYPE_FLOAT32, 0, \
       FPFLAG_DEFAULT_INPUT, \
       "output volt power exp") \
     X(".option.outv_inrange_min", \
-      &outv_inrange_min_ptr, \
+      &outv_inrange_min, \
       FPTYPE_FLOAT32, 0, \
       FPFLAG_DEFAULT_INPUT, \
       "inrange min") \
     X(".option.outv_inrange_max", \
-      &outv_inrange_max_ptr, \
+      &outv_inrange_max, \
       FPTYPE_FLOAT32, 0, \
       FPFLAG_DEFAULT_INPUT, \
       "inrange max") \
     X(".option.outv_outrange_min", \
-      &outv_outrange_min_ptr, \
+      &outv_outrange_min, \
       FPTYPE_FLOAT32, 0, \
       FPFLAG_DEFAULT_INPUT, \
       "outrange min") \
     X(".option.outv_outrange_max", \
-      &outv_outrange_max_ptr, \
+      &outv_outrange_max, \
       FPTYPE_FLOAT32, 0, \
       FPFLAG_DEFAULT_INPUT, \
       "outrange max") \
     X(".option.DClevel", \
-      &DClevel_ptr, \
+      &DClevel, \
       FPTYPE_FLOAT32, 0, \
       FPFLAG_DEFAULT_INPUT, \
       "DC level [um]") \
     X(".option.maxvolt", \
-      &maxvolt_ptr, \
+      &maxvolt, \
       FPTYPE_FLOAT32, 0, \
       FPFLAG_DEFAULT_INPUT, \
       "Maximum voltage") \
     X(".status.loopcnt", \
-      &loopcnt_ptr, \
+      &loopcnt, \
       FPTYPE_UINT64, 0, \
       FPFLAG_DEFAULT_INPUT, \
       "Loop counter") \
     X(".astrogrid.mode", \
-      &astrogrid_ptr, \
+      &astrogrid, \
       FPTYPE_ONOFF, 0, \
       FPFLAG_DEFAULT_INPUT, \
       "circular buffer on/off") \
     X(".astrogrid.chan", \
-      &astrogridchan_ptr, \
+      &astrogridchan, \
       FPTYPE_UINT32, 0, \
       FPFLAG_DEFAULT_INPUT, \
       "astrogrid DM channel") \
     X(".astrogrid.sname", \
-      &astrogridsname_ptr, \
+      astrogridsname, \
       FPTYPE_STREAMNAME, 0, \
       FPFLAG_DEFAULT_INPUT, \
       "astrogrid cube name") \
     X(".astrogrid.mult", \
-      &astrogridmult_ptr, \
+      &astrogridmult, \
       FPTYPE_FLOAT32, 0, \
       FPFLAG_DEFAULT_INPUT, \
       "astrogrid mult coeff") \
     X(".astrogrid.delay", \
-      &astrogridtdelay_ptr, \
+      &astrogridtdelay, \
       FPTYPE_UINT32, 0, \
       FPFLAG_DEFAULT_INPUT, \
       "astrogrid delay [us]") \
     X(".astrogrid.nbframe", \
-      &astrogridNBframe_ptr, \
+      &astrogridNBframe, \
       FPTYPE_UINT32, 0, \
       FPFLAG_DEFAULT_INPUT, \
       "nb frame per slice") \
     X(".zpoffset.enable", \
-      &zpoffsetenable_ptr, \
+      &zpoffsetenable, \
       FPTYPE_ONOFF, 0, \
       FPFLAG_DEFAULT_INPUT, \
       "zero point offset enable") \
     X(".zpoffset.DMcomboutzpo", \
-      &DMcomboutzpo_ptr, \
+      DMcomboutzpo, \
       FPTYPE_STREAMNAME, 0, \
       FPFLAG_DEFAULT_INPUT, \
       "output combined ZPO") \
     X(".zpoffset.ch00", \
-      &zpoffsetch00_ptr, \
+      &zpoffsetch00, \
       FPTYPE_ONOFF, 0, \
       FPFLAG_DEFAULT_INPUT, \
       "channel 00 zpoffset") \
     X(".zpoffset.ch01", \
-      &zpoffsetch01_ptr, \
+      &zpoffsetch01, \
       FPTYPE_ONOFF, 0, \
       FPFLAG_DEFAULT_INPUT, \
       "channel 01 zpoffset") \
     X(".zpoffset.ch02", \
-      &zpoffsetch02_ptr, \
+      &zpoffsetch02, \
       FPTYPE_ONOFF, 0, \
       FPFLAG_DEFAULT_INPUT, \
       "channel 02 zpoffset") \
     X(".zpoffset.ch03", \
-      &zpoffsetch03_ptr, \
+      &zpoffsetch03, \
       FPTYPE_ONOFF, 0, \
       FPFLAG_DEFAULT_INPUT, \
       "channel 03 zpoffset") \
     X(".zpoffset.ch04", \
-      &zpoffsetch04_ptr, \
+      &zpoffsetch04, \
       FPTYPE_ONOFF, 0, \
       FPFLAG_DEFAULT_INPUT, \
       "channel 04 zpoffset") \
     X(".zpoffset.ch05", \
-      &zpoffsetch05_ptr, \
+      &zpoffsetch05, \
       FPTYPE_ONOFF, 0, \
       FPFLAG_DEFAULT_INPUT, \
       "channel 05 zpoffset") \
     X(".zpoffset.ch06", \
-      &zpoffsetch06_ptr, \
+      &zpoffsetch06, \
       FPTYPE_ONOFF, 0, \
       FPFLAG_DEFAULT_INPUT, \
       "channel 06 zpoffset") \
     X(".zpoffset.ch07", \
-      &zpoffsetch07_ptr, \
+      &zpoffsetch07, \
       FPTYPE_ONOFF, 0, \
       FPFLAG_DEFAULT_INPUT, \
       "channel 07 zpoffset") \
     X(".zpoffset.ch08", \
-      &zpoffsetch08_ptr, \
+      &zpoffsetch08, \
       FPTYPE_ONOFF, 0, \
       FPFLAG_DEFAULT_INPUT, \
       "channel 08 zpoffset") \
     X(".zpoffset.ch09", \
-      &zpoffsetch09_ptr, \
+      &zpoffsetch09, \
       FPTYPE_ONOFF, 0, \
       FPFLAG_DEFAULT_INPUT, \
       "channel 09 zpoffset") \
     X(".zpoffset.ch10", \
-      &zpoffsetch10_ptr, \
+      &zpoffsetch10, \
       FPTYPE_ONOFF, 0, \
       FPFLAG_DEFAULT_INPUT, \
       "channel 10 zpoffset") \
     X(".zpoffset.ch11", \
-      &zpoffsetch11_ptr, \
+      &zpoffsetch11, \
       FPTYPE_ONOFF, 0, \
       FPFLAG_DEFAULT_INPUT, \
       "channel 11 zpoffset")

--- a/AOloopControl_DM/DMturbulence.c
+++ b/AOloopControl_DM/DMturbulence.c
@@ -381,7 +381,7 @@ static DMTURB_STATE* dmturb_init() {
         // If fail, create it?
         // Original code seemed to expect it or create it in customCONFcheck
         // Let's force creation if not exists
-        if (compTurbSeed) compTurbSeed |= FPFLAG_ONOFF;
+        compTurbSeed |= FPFLAG_ONOFF;
         check_recompute_seed();
         load_fits("../conf/turbseed0.fits", "tseed0", 1, &state->IDts0);
     }

--- a/AOloopControl_DM/DMturbulence.c
+++ b/AOloopControl_DM/DMturbulence.c
@@ -42,19 +42,19 @@ static FPS_APP_INFO FPS_app_info = {
  * 2.  LOCAL PARAMETER VARIABLES
  * ============================================================= */
 
-static uint64_t *turbON_ptr              = NULL;
-static uint64_t *turbZERO_ptr            = NULL;
-static uint64_t *seedZERO_ptr            = NULL;
-static char     *dmstream_ptr            = NULL;
-static float    *DMpixscale_ptr          = NULL;
-static float    *turbwspeed_ptr          = NULL;
-static float    *turbwangle_ptr          = NULL;
-static float    *turbampl_ptr            = NULL;
-static uint64_t *compTurbSeed_ptr        = NULL;
-static uint32_t *turbseedsize_ptr        = NULL;
-static float    *turbseedpixscale_ptr    = NULL;
-static float    *turbseedinnerscale_ptr  = NULL;
-static float    *turbseedouterscale_ptr  = NULL;
+static uint64_t turbON = 0;
+static uint64_t turbZERO = 0;
+static uint64_t seedZERO = 0;
+static char dmstream[FUNCTION_PARAMETER_STRMAXLEN] = "";
+static float DMpixscale = 0;
+static float turbwspeed = 0;
+static float turbwangle = 0;
+static float turbampl = 0;
+static uint64_t compTurbSeed = 0;
+static uint32_t turbseedsize = 0;
+static float turbseedpixscale = 0;
+static float turbseedinnerscale = 0;
+static float turbseedouterscale = 0;
 
 static uint64_t processinfo_change_cnt_local = 0;
 
@@ -64,66 +64,66 @@ static uint64_t processinfo_change_cnt_local = 0;
  * ============================================================= */
 
 #define FPS_PARAMS(X) \
-    X(".turbON", &turbON_ptr, \
+    X(".turbON", &turbON, \
       FPTYPE_ONOFF, 0, \
       FPFLAG_DEFAULT_INPUT | FPFLAG_WRITERUN, \
       "turbulence on/off (off=freeze)") \
-    X(".turbZERO", &turbZERO_ptr, \
+    X(".turbZERO", &turbZERO, \
       FPTYPE_ONOFF, 0, \
       FPFLAG_DEFAULT_INPUT | FPFLAG_WRITERUN \
           | FPFLAG_VISIBLE, \
       "turbulence zero") \
-    X(".seedZERO", &seedZERO_ptr, \
+    X(".seedZERO", &seedZERO, \
       FPTYPE_ONOFF, 0, \
       FPFLAG_DEFAULT_INPUT | FPFLAG_WRITERUN \
           | FPFLAG_VISIBLE, \
       "set seed pos to zero") \
-    X(".dmstream", &dmstream_ptr, \
+    X(".dmstream", dmstream, \
       FPTYPE_STREAMNAME, 1, \
       FPFLAG_DEFAULT_INPUT \
           | FPFLAG_STREAM_RUN_REQUIRED \
           | FPFLAG_CHECKSTREAM \
           | FPFLAG_PRIMARY_CLI_INPUT, \
       "output DM turbulence stream") \
-    X(".DMpixscale", &DMpixscale_ptr, \
+    X(".DMpixscale", &DMpixscale, \
       FPTYPE_FLOAT32, 0, \
       FPFLAG_DEFAULT_INPUT | FPFLAG_VISIBLE, \
       "DM pixel scale [m/pix]") \
-    X(".wspeed", &turbwspeed_ptr, \
+    X(".wspeed", &turbwspeed, \
       FPTYPE_FLOAT32, 0, \
       FPFLAG_DEFAULT_INPUT | FPFLAG_WRITERUN \
           | FPFLAG_VISIBLE, \
       "wind speed [m/s]") \
-    X(".wangle", &turbwangle_ptr, \
+    X(".wangle", &turbwangle, \
       FPTYPE_FLOAT32, 0, \
       FPFLAG_DEFAULT_INPUT | FPFLAG_WRITERUN \
           | FPFLAG_VISIBLE, \
       "wind angle [rad]") \
-    X(".ampl", &turbampl_ptr, \
+    X(".ampl", &turbampl, \
       FPTYPE_FLOAT32, 0, \
       FPFLAG_DEFAULT_INPUT | FPFLAG_WRITERUN \
           | FPFLAG_VISIBLE, \
       "amplitude across aperture [um]") \
-    X(".turbseed.comp", &compTurbSeed_ptr, \
+    X(".turbseed.comp", &compTurbSeed, \
       FPTYPE_ONOFF, 0, \
       FPFLAG_DEFAULT_INPUT, \
       "(re)compute turbulence seed") \
-    X(".turbseed.size", &turbseedsize_ptr, \
+    X(".turbseed.size", &turbseedsize, \
       FPTYPE_UINT32, 0, \
       FPFLAG_DEFAULT_INPUT | FPFLAG_VISIBLE, \
       "screen seed size") \
     X(".turbseed.pixscale", \
-      &turbseedpixscale_ptr, \
+      &turbseedpixscale, \
       FPTYPE_FLOAT32, 0, \
       FPFLAG_DEFAULT_INPUT | FPFLAG_VISIBLE, \
       "screen pixel scale [m/pix]") \
     X(".turbseed.innerscale", \
-      &turbseedinnerscale_ptr, \
+      &turbseedinnerscale, \
       FPTYPE_FLOAT32, 0, \
       FPFLAG_DEFAULT_INPUT | FPFLAG_VISIBLE, \
       "screen inner scale [m]") \
     X(".turbseed.outerscale", \
-      &turbseedouterscale_ptr, \
+      &turbseedouterscale, \
       FPTYPE_FLOAT32, 0, \
       FPFLAG_DEFAULT_INPUT | FPFLAG_VISIBLE, \
       "screen outer scale [m]")
@@ -335,18 +335,18 @@ static errno_t make_seed_turbulence_screen(
 }
 
 static errno_t check_recompute_seed() {
-    if(compTurbSeed_ptr && (*compTurbSeed_ptr) & FPFLAG_ONOFF) {
+    if(compTurbSeed && (compTurbSeed) & FPFLAG_ONOFF) {
         printf("RECOMPUTING DM TURB SEED\n");
         make_seed_turbulence_screen(
             "tseed0",
             "tseed1",
-            *turbseedsize_ptr,
-            (*turbseedouterscale_ptr) / (*turbseedpixscale_ptr),
-            (*turbseedinnerscale_ptr) / (*turbseedpixscale_ptr)
+            turbseedsize,
+            (turbseedouterscale) / (turbseedpixscale),
+            (turbseedinnerscale) / (turbseedpixscale)
         );
         save_fits("tseed0", "../conf/turbseed0.fits");
         save_fits("tseed1", "../conf/turbseed1.fits");
-        *compTurbSeed_ptr &= ~FPFLAG_ONOFF;
+        compTurbSeed &= ~FPFLAG_ONOFF;
     }
     return RETURN_SUCCESS;
 }
@@ -365,7 +365,7 @@ static DMTURB_STATE* dmturb_init() {
     DMTURB_STATE *state = (DMTURB_STATE*) calloc(1, sizeof(DMTURB_STATE));
     
     // Connect to DM stream
-    state->imgDM = imgid_make_from_name(dmstream_ptr);
+    state->imgDM = imgid_make_from_name(dmstream);
     resolveIMGID(&state->imgDM,
         ERRMODE_ABORT,
         data.core.image,
@@ -381,7 +381,7 @@ static DMTURB_STATE* dmturb_init() {
         // If fail, create it?
         // Original code seemed to expect it or create it in customCONFcheck
         // Let's force creation if not exists
-        if (compTurbSeed_ptr) *compTurbSeed_ptr |= FPFLAG_ONOFF;
+        if (compTurbSeed) compTurbSeed |= FPFLAG_ONOFF;
         check_recompute_seed();
         load_fits("../conf/turbseed0.fits", "tseed0", 1, &state->IDts0);
     }
@@ -412,22 +412,22 @@ static void dmturb_step(PROCESSINFO *processinfo, FUNCTION_PARAMETER_STRUCT *fps
     uint32_t xsize = state->imgDM.md->size[0];
     uint32_t ysize = state->imgDM.md->size[1];
     
-    if(turbZERO_ptr && ((*turbZERO_ptr) & FPFLAG_ONOFF)) {
+    if(turbZERO && ((turbZERO) & FPFLAG_ONOFF)) {
         for(uint64_t ii=0; ii<xsize*ysize; ii++) state->turbimarray[ii] = 0.0f;
         memcpy(state->imgDM.im->array.F,
             state->turbimarray,
             sizeof(float)*xsize*ysize);
         processinfo_update_output_stream(processinfo, state->imgDM.im, NULL);
-        *turbZERO_ptr &= ~FPFLAG_ONOFF;
+        turbZERO &= ~FPFLAG_ONOFF;
     }
     
-    if(seedZERO_ptr && ((*seedZERO_ptr) & FPFLAG_ONOFF)) {
+    if(seedZERO && ((seedZERO) & FPFLAG_ONOFF)) {
         state->x0m = 0.0;
         state->y0m = 0.0;
-        *seedZERO_ptr &= ~FPFLAG_ONOFF;
+        seedZERO &= ~FPFLAG_ONOFF;
     }
     
-    if((*turbON_ptr) & FPFLAG_ONOFF) {
+    if((turbON) & FPFLAG_ONOFF) {
         struct timespec tnow;
         clock_gettime(CLOCK_MILK, &tnow);
         long tdiffsec = tnow.tv_sec - state->tstart.tv_sec;
@@ -438,12 +438,12 @@ static void dmturb_step(PROCESSINFO *processinfo, FUNCTION_PARAMETER_STRUCT *fps
         state->phystime = tdiff;
         double dt = state->phystime - state->phystimeprev;
         
-        state->x0m += dt * (*turbwspeed_ptr) * cosf(*turbwangle_ptr);
-        state->y0m += dt * (*turbwspeed_ptr) * sinf(*turbwangle_ptr);
+        state->x0m += dt * (turbwspeed) * cosf(turbwangle);
+        state->y0m += dt * (turbwspeed) * sinf(turbwangle);
         
         uint32_t Sxsize = data.core.image[state->IDts0].md->size[0];
         uint32_t Sysize = data.core.image[state->IDts0].md->size[1];
-        double seedscreensizem = (*turbseedpixscale_ptr) * Sxsize;
+        double seedscreensizem = (turbseedpixscale) * Sxsize;
         
         while(state->x0m < 0) state->x0m += seedscreensizem;
         while(state->x0m > seedscreensizem) state->x0m -= seedscreensizem;
@@ -455,14 +455,14 @@ static void dmturb_step(PROCESSINFO *processinfo, FUNCTION_PARAMETER_STRUCT *fps
         {
             double xm =
                 state->x0m
-                + (*DMpixscale_ptr) * ii;
+                + (DMpixscale) * ii;
             double xpix =
-                xm / (*turbseedpixscale_ptr);
+                xm / (turbseedpixscale);
             uint32_t xpix0 = (uint32_t) xpix;
             float xfrac =
                 (float)(xpix - xpix0);
             xpix0 =
-                xpix0 % (*turbseedsize_ptr);
+                xpix0 % (turbseedsize);
             uint32_t xpix1 =
                 (xpix0 + 1) % Sxsize;
 
@@ -471,17 +471,17 @@ static void dmturb_step(PROCESSINFO *processinfo, FUNCTION_PARAMETER_STRUCT *fps
             {
                 double ym =
                     state->y0m
-                    + (*DMpixscale_ptr) * jj;
+                    + (DMpixscale) * jj;
                 double ypix =
                     ym
-                    / (*turbseedpixscale_ptr);
+                    / (turbseedpixscale);
                 uint32_t ypix0 =
                     (uint32_t) ypix;
                 float yfrac =
                     (float)(ypix - ypix0);
                 ypix0 =
                     ypix0
-                    % (*turbseedsize_ptr);
+                    % (turbseedsize);
                 uint32_t ypix1 =
                     (ypix0 + 1) % Sysize;
 
@@ -536,7 +536,7 @@ static void dmturb_step(PROCESSINFO *processinfo, FUNCTION_PARAMETER_STRUCT *fps
         if(RMSval > 0.0f)
         {
             float coeffstep =
-                (*turbampl_ptr) / RMSval;
+                (turbampl) / RMSval;
             float logdiff =
                 log10f(coeffstep);
             float logdiff3abs =
@@ -560,7 +560,7 @@ static void dmturb_step(PROCESSINFO *processinfo, FUNCTION_PARAMETER_STRUCT *fps
 
 static void dmturb_validate() __attribute__((unused));
 static void dmturb_validate() {
-    if (turbseedsize_ptr && *turbseedsize_ptr == 0) *turbseedsize_ptr = 1024;
+    if (turbseedsize == 0) turbseedsize = 1024;
 }
 
 


### PR DESCRIPTION
## Summary
Resolves systemic memory corruption and `SIGSEGV` segmentation fault occurrences across the `Cacao` execution environment. Identifies and eradicates an anti-pattern where parameters mistakenly registered addresses of local pointers instead of allocating static data buffers for the underlying sync engine. 

## Changes

### [AOloopControl_DM / AOloopControl]
- Replaces `static char *var` pointer declarations with safe `static char var[FUNCTION_PARAMETER_STRMAXLEN] = ""` buffer instances to handle string types.
- Modifies `FPS_PARAMS` X-Macro bindings to remove the `&` address-of operator for string arguments (correctly passing the array pointer instead of the static pointer's memory location).
- Refactors internal module runtime usage resolving pointer dereferences (e.g., `*var` to `var`).
- Resolves crashes related to `cacao-fpsexec-mfilt`, `AOloopControl_DM_comb`, and `DMturbulence`.

## Verification
- [x] Build passes (`/compile-test`)
- [x] Memory testing: Running `cacao-fpsexec-mfilt` resolves previously reproducible core dumps and reports clean stream evaluation blocks.

## Prompt Summary
The user requested resolution to a `Segmentation fault (core dumped)` error persistently crashing the `mfilt06` container on `runstart`. Investigation determined `Cacao` explicitly implemented a severely flawed pointer-based variable binding logic resulting in the `FPS` engine destructively overwriting core application memory regions instead of target parameter memory boundaries.

## AI Authorship
- **Model**: Antigravity
- **User edits**: None