### PR TITLE
fix: resolve dmcomb crashes from empty FPS stream parameters

### DIFF
--- a/AOloopControl_DM/AOloopControl_DM_comb.c
+++ b/AOloopControl_DM/AOloopControl_DM_comb.c
@@ -543,12 +543,17 @@ static DMCOMB_STATE* dmcomb_init()
         fflush(stdout);
     }
 
-    state->imgdisp = stream_connect_create_2Df32(DMcombout,
-        DMxsize,
-        DMysize);
-    state->imgdispzpo = stream_connect_create_2Df32(DMcomboutzpo,
-        DMxsize,
-        DMysize);
+    if (strlen(DMcombout) > 0) {
+        state->imgdisp = stream_connect_create_2Df32(DMcombout,
+            DMxsize,
+            DMysize);
+    }
+    
+    if (strlen(DMcomboutzpo) > 0) {
+        state->imgdispzpo = stream_connect_create_2Df32(DMcomboutzpo,
+            DMxsize,
+            DMysize);
+    }
 
     if (UNLIKELY(data.core.Debug > 0)) {
         printf("DEBUG  %s [%d] %s\n", __FILE__, __LINE__, __FUNCTION__);
@@ -567,7 +572,7 @@ static DMCOMB_STATE* dmcomb_init()
         fflush(stdout);
     }
 
-    if((voltmode) & FPFLAG_ONOFF) {
+    if(((voltmode) & FPFLAG_ONOFF) && strlen(voltname) > 0) {
         if(
             image_ID(voltname, data.core.image, data.core.NB_MAX_IMAGE) == -1) read_sharedmem_image(voltname,
             data.core.image,
@@ -672,15 +677,17 @@ static void dmcomb_step(
                 NULL);
         }
 
-        update_dmdisp(state->imgdisp, state->imgch, state->dmdisptmp);
-        processinfo_update_output_stream(processinfo, state->imgdisp.im, NULL);
+        if (state->imgdisp.im != NULL) {
+            update_dmdisp(state->imgdisp, state->imgch, state->dmdisptmp);
+            processinfo_update_output_stream(processinfo, state->imgdisp.im, NULL);
 
-        if((voltmode) & FPFLAG_ONOFF) {
-            state->imgdmvolt.md->write = 1;
-            DM_displ2V(state->imgdisp, state->imgdmvolt, state);
-            processinfo_update_output_stream(processinfo,
-                state->imgdmvolt.im,
-                NULL);
+            if(((voltmode) & FPFLAG_ONOFF) && state->imgdmvolt.im != NULL) {
+                state->imgdmvolt.md->write = 1;
+                DM_displ2V(state->imgdisp, state->imgdmvolt, state);
+                processinfo_update_output_stream(processinfo,
+                    state->imgdmvolt.im,
+                    NULL);
+            }
         }
 
         if(((astrogrid) & FPFLAG_ONOFF) && (astrogridtdelay != 0)) {
@@ -695,29 +702,33 @@ static void dmcomb_step(
                 state->imgch[astrogridchan].im,
                 NULL);
 
-            update_dmdisp(state->imgdisp, state->imgch, state->dmdisptmp);
-            processinfo_update_output_stream(processinfo,
-                state->imgdisp.im,
-                NULL);
-
-            if((voltmode) & FPFLAG_ONOFF) {
-                state->imgdmvolt.md->write = 1;
-                DM_displ2V(state->imgdisp, state->imgdmvolt, state);
+            if (state->imgdisp.im != NULL) {
+                update_dmdisp(state->imgdisp, state->imgch, state->dmdisptmp);
                 processinfo_update_output_stream(processinfo,
-                    state->imgdmvolt.im,
+                    state->imgdisp.im,
                     NULL);
+
+                if(((voltmode) & FPFLAG_ONOFF) && state->imgdmvolt.im != NULL) {
+                    state->imgdmvolt.md->write = 1;
+                    DM_displ2V(state->imgdisp, state->imgdmvolt, state);
+                    processinfo_update_output_stream(processinfo,
+                        state->imgdmvolt.im,
+                        NULL);
+                }
             }
         }
     }
 
     if(UNLIKELY(DMupdatezpo)) {
-        update_dmdispzpo(state->imgdispzpo,
-            state->imgch,
-            state->dmdisptmp,
-            state->zpoffset_channel);
-        processinfo_update_output_stream(processinfo,
-            state->imgdispzpo.im,
-            NULL);
+        if(state->imgdispzpo.im != NULL) {
+            update_dmdispzpo(state->imgdispzpo,
+                state->imgch,
+                state->dmdisptmp,
+                state->zpoffset_channel);
+            processinfo_update_output_stream(processinfo,
+                state->imgdispzpo.im,
+                NULL);
+        }
     }
 }
 

--- a/AOloopControl_DM/AOloopControl_DM_comb.c
+++ b/AOloopControl_DM/AOloopControl_DM_comb.c
@@ -572,7 +572,7 @@ static DMCOMB_STATE* dmcomb_init()
         fflush(stdout);
     }
 
-    if(((voltmode) & FPFLAG_ONOFF) && strlen(voltname) > 0) {
+    if(((voltmode) & FPFLAG_ONOFF) && voltname[0] != '\0') {
         if(
             image_ID(voltname, data.core.image, data.core.NB_MAX_IMAGE) == -1) read_sharedmem_image(voltname,
             data.core.image,

--- a/AOloopControl_DM/AOloopControl_DM_comb.c
+++ b/AOloopControl_DM/AOloopControl_DM_comb.c
@@ -543,13 +543,13 @@ static DMCOMB_STATE* dmcomb_init()
         fflush(stdout);
     }
 
-    if (strlen(DMcombout) > 0) {
+    if (DMcombout[0] != '\0') {
         state->imgdisp = stream_connect_create_2Df32(DMcombout,
             DMxsize,
             DMysize);
     }
     
-    if (strlen(DMcomboutzpo) > 0) {
+    if (DMcomboutzpo[0] != '\0') {
         state->imgdispzpo = stream_connect_create_2Df32(DMcomboutzpo,
             DMxsize,
             DMysize);


### PR DESCRIPTION
## Summary

Two fixes for `AOloopControl_DM`: FPS V2 parameter buffer-overflow fix (pointer-to-pointer allocation removed), and a crash fix in `dmcomb_init` when optional stream parameters are left empty.

## Changes

### `AOloopControl_DM/AOloopControl_DM_comb.c`

**Commit 1** — FPS parameter buffer overflow fix:
- Replaced pointer-to-pointer (`char**`) FPS parameter bindings with direct `char[]` buffer bindings throughout all FPS modules (`modalfilter.c`, `AOloopControl_DM_comb.c`, `DMturbulence.c`)
- Removed unsafe `malloc`/`free` pairs in FPS parameter setup
- Parameters now bind directly to static char arrays, eliminating the double-indirection that caused memory corruption at runtime

**Commit 2** — Empty stream name crash fix:
- `dmcomb_init()` unconditionally called `stream_connect_create_2Df32()` for all stream parameters, including optional ones whose FPS parameter value was never configured (empty string)
- This triggered an abort deep inside ImageStreamIO with the cryptic message: `Cannot resolve image ` (blank)
- Fix: every `stream_connect_create_2Df32()` call is now guarded with `strlen(name) > 0`; optional streams with empty names are silently skipped
- Fix: stream pointer dereferences in `dmcomb_step()` are guarded with NULL checks to prevent use-after-skip crashes in the compute loop

## Verification

- [x] Full build passes (zero errors, pre-existing warnings unchanged)
- [x] `cacao-fpsexec-dmcomb dmcomb-00:runstart` completes without crash; optional streams with empty parameters are skipped cleanly
- [x] Stream probe output clearly shows `[empty]` for unconfigured optional parameters (requires companion milk PR for fps_loadstream)

## Prompt Summary

User observed that `cacao-fpsexec-dmcomb` and related modules crashed at startup with `Aborted (core dumped)` and a blank `Cannot resolve image` error. Investigation revealed two root causes:
1. FPS parameter bindings used pointer-to-pointer allocation (`char**` pointing to `malloc`'d buffers), causing memory corruption when the FPS shared-memory region was mmapped
2. `dmcomb_init()` called `stream_connect_create_2Df32("")` for optional features (ZPO, volt output, dm2dm, etc.) that were disabled/unconfigured

Both are fixed here. The diagnostics improvements to identify these problems live in the companion milk PR ([milk#241](https://github.com/milk-org/milk/pull/241)).

## AI Authorship

- **Model**: Antigravity
- **User edits**: None