### PR TITLE
feat: migrate all write flag and cnt0 accesses to atomic macros

### DIFF
--- a/AOloopControl_DM/AOloopControl_DM_comb.c
+++ b/AOloopControl_DM/AOloopControl_DM_comb.c
@@ -682,7 +682,7 @@ static void dmcomb_step(
             processinfo_update_output_stream(processinfo, state->imgdisp.im, NULL);
 
             if(((voltmode) & FPFLAG_ONOFF) && state->imgdmvolt.im != NULL) {
-                state->imgdmvolt.md->write = 1;
+                SHMIM_WRITE_ACQUIRE(state->imgdmvolt.md);
                 DM_displ2V(state->imgdisp, state->imgdmvolt, state);
                 processinfo_update_output_stream(processinfo,
                     state->imgdmvolt.im,
@@ -709,7 +709,7 @@ static void dmcomb_step(
                     NULL);
 
                 if(((voltmode) & FPFLAG_ONOFF) && state->imgdmvolt.im != NULL) {
-                    state->imgdmvolt.md->write = 1;
+                    SHMIM_WRITE_ACQUIRE(state->imgdmvolt.md);
                     DM_displ2V(state->imgdisp, state->imgdmvolt, state);
                     processinfo_update_output_stream(processinfo,
                         state->imgdmvolt.im,

--- a/AOloopControl_IOtools/acquireWFSim.c
+++ b/AOloopControl_IOtools/acquireWFSim.c
@@ -323,7 +323,7 @@ static errno_t compute_function()
             clock_gettime(CLOCK_MILK, &time1);
         }
 
-        imgimWFS0.md->write = 1;
+        SHMIM_WRITE_ACQUIRE(imgimWFS0.md);
 
         switch(WFSatype)
         {
@@ -428,7 +428,7 @@ static errno_t compute_function()
         {
             clock_gettime(CLOCK_MILK, &time1);
         }
-        imgimWFS1.md->write = 1;
+        SHMIM_WRITE_ACQUIRE(imgimWFS1.md);
 
         if(functionparameter_GetParamValue_ONOFF(
                 data.core.fpsptr, ".comp.WFSnormalize") == 1)
@@ -531,7 +531,7 @@ static errno_t compute_function()
         {
             // subtract reference
             status_refsub = 1;
-            imgimWFS2.md->write = 1;
+            SHMIM_WRITE_ACQUIRE(imgimWFS2.md);
 
             if(imgwfsrefc.ID != -1)
             {
@@ -548,7 +548,7 @@ static errno_t compute_function()
         }
         else
         {
-            imgimWFS2.md->write = 1;
+            SHMIM_WRITE_ACQUIRE(imgimWFS2.md);
             memcpy(imgimWFS2.im->array.F,
                    imgimWFS1.im->array.F,
                    sizeof(float) * sizeWFS);
@@ -575,7 +575,7 @@ static errno_t compute_function()
                 data.core.fpsptr, ".comp.WFSsigav") == 1)
         {
             status_ave = 1;
-            imgimWFS3.md->write = 1;
+            SHMIM_WRITE_ACQUIRE(imgimWFS3.md);
             float tave_gain = *WFStaveragegain;
             float tave_mult = *WFStaveragemult;
             for(uint64_t ii = 0; ii < sizeWFS; ii++)
@@ -635,7 +635,7 @@ static errno_t compute_function()
                 data.core.fpsptr, ".comp.WFSrefc") == 1)
         {
             status_wfsrefc = 1;
-            imgwfsrefc.md->write = 1;
+            SHMIM_WRITE_ACQUIRE(imgwfsrefc.md);
             float refcgain = *WFSrefcgain;
             float refcmult = *WFSrefcmult;
             if(imgwfsref.ID != -1)

--- a/AOloopControl_IOtools/acquireWFSspec.c
+++ b/AOloopControl_IOtools/acquireWFSspec.c
@@ -355,7 +355,7 @@ static errno_t compute_function()
             }
         }
 
-        imgimWFS0.md->write = 1;
+        SHMIM_WRITE_ACQUIRE(imgimWFS0.md);
 
         if(status_darksub == 0)
         {
@@ -375,7 +375,7 @@ static errno_t compute_function()
 
         // STEP 3: NORMALIZATION
         int status_normalize __attribute__((unused)) = 0;
-        imgimWFS1.md->write = 1;
+        SHMIM_WRITE_ACQUIRE(imgimWFS1.md);
 
         long fpi_compWFSnormalize = 
             functionparameter_GetParamIndex(
@@ -396,7 +396,7 @@ static errno_t compute_function()
         // STEP 4: REFERENCE SUBTRACTION
 
         int status_refsub __attribute__((unused)) = 0;
-        imgimWFS2.md->write = 1;
+        SHMIM_WRITE_ACQUIRE(imgimWFS2.md);
         long fpi_compWFSrefsub = 
             functionparameter_GetParamIndex(
                 data.core.fpsptr, ".comp.WFSrefsub");

--- a/AOloopControl_IOtools/ao188_preprocessor.c
+++ b/AOloopControl_IOtools/ao188_preprocessor.c
@@ -335,7 +335,7 @@ static errno_t compute_function()
 
 
         // Begin with LOWFS computations
-        lowfs_info.im->md->write = 1;
+        SHMIM_WRITE_ACQUIRE(lowfs_info.im->md);
         compute_lowfs_info(lowfs_info_ptr, apd_lowfs_ptr);
         processinfo_update_output_stream(processinfo, lowfs_info.im, NULL);
 
@@ -346,7 +346,7 @@ static errno_t compute_function()
 
         // HOWFS curvature computations
         // TODO Pass keywords through. Or don't?
-        curv_2k_doublesided.im->md->write = 1;
+        SHMIM_WRITE_ACQUIRE(curv_2k_doublesided.im->md);
         two_sided_curvature_compute(curv_2k_doublesided.im->array.F,
             apd_mat_in.im->array.SI16,
             NUM_APD_TOTAL,
@@ -358,7 +358,7 @@ static errno_t compute_function()
         // Post outputs
         if(curv_sign == 1)
         {
-            curv_1k_doublesided.im->md->write = 1;
+            SHMIM_WRITE_ACQUIRE(curv_1k_doublesided.im->md);
             memcpy(curv_1k_doublesided.im->array.F, curv_2k_doublesided.im->array.F,
                    NUM_APD_HOWFS * sizeof(float));
             processinfo_update_output_stream(processinfo,
@@ -366,7 +366,7 @@ static errno_t compute_function()
                 NULL);
         }
 
-        curv_2k_singlesided.im->md->write = 1;
+        SHMIM_WRITE_ACQUIRE(curv_2k_singlesided.im->md);
         // Get the latest side of the APD 216x2 buffer. WARNING: Size may be 217 if the curvature tag is embedded!
         // apd_mat_in.size[0] = 216 or 217 =/= NUM_APD_HOWFS.
 

--- a/AOloopControl_PredictiveControl/AOloopControl_PredictiveControl_builPFloop_WatchInput.c
+++ b/AOloopControl_PredictiveControl/AOloopControl_PredictiveControl_builPFloop_WatchInput.c
@@ -354,7 +354,7 @@ imageID AOloopControl_PredictiveControl_builPFloop_WatchInput(
 
         if(Tupdate == 1)
         {
-            data.core.image[IDout].md[0].write = 1;
+            SHMIM_WRITE_ACQUIRE(&data.core.image[IDout].md[0]);
             long kkin;
             for(kkin = 0; kkin < zsizein; kkin++)
             {
@@ -364,7 +364,7 @@ imageID AOloopControl_PredictiveControl_builPFloop_WatchInput(
                         data.core.image[IDinb]
                         .array.F[kkin * xysize + (ii + PFblockStart)];
             }
-            data.core.image[IDout].md[0].write = 0;
+            SHMIM_WRITE_RELEASE(&data.core.image[IDout].md[0]);
 
             printf("[%3ld/%3ld  %d]\n", buffindex, NBbuff, cube);
             Tupdate = 0;
@@ -384,7 +384,7 @@ imageID AOloopControl_PredictiveControl_builPFloop_WatchInput(
                 timenow.tv_nsec,
                 outcnt);
 
-            data.core.image[IDout].md[0].write = 1;
+            SHMIM_WRITE_ACQUIRE(&data.core.image[IDout].md[0]);
             for(ii = 0; ii < PFblockSize; ii++)  // Remove time averaged value
             {
                 ave = 0.0;
@@ -401,8 +401,8 @@ imageID AOloopControl_PredictiveControl_builPFloop_WatchInput(
             }
 
             COREMOD_MEMORY_image_set_sempost_byID(IDout, -1);
-            data.core.image[IDout].md[0].cnt0++;
-            data.core.image[IDout].md[0].write = 0;
+            SHMIM_CNT0_INCREMENT(&data.core.image[IDout].md[0]);
+            SHMIM_WRITE_RELEASE(&data.core.image[IDout].md[0]);
 
             buffindex = 0;
             outcnt++;

--- a/AOloopControl_acquireCalib/measure_linear_resp.c
+++ b/AOloopControl_acquireCalib/measure_linear_resp.c
@@ -620,7 +620,7 @@ static errno_t Measure_Linear_Response_Modal(
             //printf("%5lu Poking\n", pokeframe);
             // Poke
             //
-            imgin.md->write = 1;
+            SHMIM_WRITE_ACQUIRE(imgin.md);
             memcpy((void *)(imgin.im->array.F),
                    (void *)(ptr0 + pkinfarray[pokeframe].PokeIndexCTRL_Mapped * framesize),
                    sizeof(float) * sizexyin);
@@ -654,7 +654,7 @@ static errno_t Measure_Linear_Response_Modal(
             {
                 arrayf[ii] = 0.0;
             }
-            imgin.md->write = 1;
+            SHMIM_WRITE_ACQUIRE(imgin.md);
             memcpy((void *)(imgin.im->array.F),
                    (void *)(arrayf),
                    sizeof(float) * sizexyin);

--- a/AOloopControl_perfTest/zoptsearch.c
+++ b/AOloopControl_perfTest/zoptsearch.c
@@ -190,7 +190,7 @@ static double image_optvalue(
     // copy to output if applicable
     if ( imgout.ID != -1 )
     {
-        imgout.md->write = 1;
+        SHMIM_WRITE_ACQUIRE(imgout.md);
         memcpy(imgout.im->array.F, imbuff, sizeof(float)*xysize);
         ImageStreamIO_UpdateIm(imgout.im);
     }
@@ -426,7 +426,7 @@ static errno_t compute_function()
             // apply control
             //
             {
-                imgctrl.md->write = 1;
+                SHMIM_WRITE_ACQUIRE(imgctrl.md);
                 if (imgctrlamp.ID == -1)
                 {
                     // no amplitude map, assume range is from -1 to +1


### PR DESCRIPTION
## Summary

Migrate all direct `md->write` assignments and `md[0].cnt0++` increments in cacao AO loop control modules to use the new `SHMIM_WRITE_*` and `SHMIM_CNT0_*` atomic accessor macros from `ImageStruct.h`.

This is the cacao-side companion to the ImageStreamIO PR (milk-org/ImageStreamIO#69) that defines the macros.

> **Dependency:** Requires milk-org/ImageStreamIO#69 to be merged first.

## Rationale

See milk-org/ImageStreamIO#69 for the full rationale on why atomic accessors are needed. The `IMAGE_METADATA.write` field serves as a cooperative mutex for shared memory streams. The existing plain `uint8_t` direct assignments lack compiler barriers and CPU memory fences, creating a class of cross-process race conditions where:

1. The compiler may cache `write` in a register, causing spinloops to never exit
2. On weakly-ordered architectures, pixel data stores may be reordered after `write = 0`, causing readers to see stale data

This PR performs the mechanical migration of ~25 call sites across 7 files.

## Backward compatibility

This is a **code-only change** — no struct layout, ABI, or SHM format changes. All modifications are source-level substitutions of direct field access with macro calls that operate on the same underlying fields at the same offsets. Existing SHM files and interprocess communication continue to work unchanged.

## Opt-in write blocking

The write flag remains an opt-in cooperative mutex. Writers now consistently use `SHMIM_WRITE_ACQUIRE/RELEASE`, ensuring that readers opting into write blocking via `ImageStreamIO_BusywaitForNoWrite()` will see complete, consistent frames with proper memory ordering.

Readers that do not call `BusywaitForNoWrite` are unaffected — they continue to read immediately after semaphore wakeup, as before. This is the default behavior for latency-critical AO loops.

## Files changed (7 files, +24 −24)

- `AOloopControl_DM/AOloopControl_DM_comb.c`
- `AOloopControl_IOtools/acquireWFSim.c`
- `AOloopControl_IOtools/acquireWFSspec.c`
- `AOloopControl_IOtools/ao188_preprocessor.c`
- `AOloopControl_PredictiveControl/AOloopControl_PredictiveControl_builPFloop_WatchInput.c`
- `AOloopControl_acquireCalib/measure_linear_resp.c`
- `AOloopControl_perfTest/zoptsearch.c`

## AI Authorship

- **Model:** Antigravity
- **User edits:** None (mechanical migration).

## Prompt Summary

Codebase-wide migration of all direct `IMAGE_METADATA.write` and `cnt0` field accesses in cacao to atomic accessor macros, as part of the cross-process race condition remediation effort.