### PR TITLE
refactor: modernize FPS architecture to V2

### DIFF
--- a/AOloopControl/modalfilter.c
+++ b/AOloopControl/modalfilter.c
@@ -357,7 +357,7 @@ static void modal_filter_cleanup(MFILT_STATE *state) {
  */
 static void modal_filter_step(
     PROCESSINFO *processinfo,
-    FUNCTION_PARAMETER_STRUCT *fps,
+    FPS *fps,
     IMAGE *imginWFS,
     IMAGE *imgout,
     MFILT_STATE *state)

--- a/AOloopControl/zonalfilter.c
+++ b/AOloopControl/zonalfilter.c
@@ -110,7 +110,7 @@ static float *zvalDMc = NULL;
 
 static void zonal_filter_step(
     PROCESSINFO              *processinfo,
-    FUNCTION_PARAMETER_STRUCT *fps __attribute__((unused)),
+    FPS *fps __attribute__((unused)),
     IMAGE *imginDM,
     IMAGE *imgout,
     IMAGE *imgzgain,

--- a/AOloopControl_DM/AOloopControl_DM_comb.c
+++ b/AOloopControl_DM/AOloopControl_DM_comb.c
@@ -597,7 +597,7 @@ static DMCOMB_STATE* dmcomb_init()
 
 static void dmcomb_step(
     PROCESSINFO *processinfo,
-    FUNCTION_PARAMETER_STRUCT *fps,
+    FPS *fps,
     DMCOMB_STATE *state
 )
 {

--- a/AOloopControl_DM/DMturbulence.c
+++ b/AOloopControl_DM/DMturbulence.c
@@ -397,7 +397,7 @@ static DMTURB_STATE* dmturb_init() {
     return state;
 }
 
-static void dmturb_step(PROCESSINFO *processinfo, FUNCTION_PARAMETER_STRUCT *fps, DMTURB_STATE *state) {
+static void dmturb_step(PROCESSINFO *processinfo, FPS *fps, DMTURB_STATE *state) {
     // Sync parameters
     if (fps) {
         if(fps->md->processinfo_change_cnt != processinfo_change_cnt_local) {

--- a/AOloopControl_acquireCalib/acquireWFSlincalib.c
+++ b/AOloopControl_acquireCalib/acquireWFSlincalib.c
@@ -29,7 +29,7 @@ static float    *pokeampl;
 static char *dmstream;
 
 // timing params
-static FUNCTION_PARAMETER_STRUCT FPS_mlat;
+static FPS FPS_mlat;
 
 // Toggles
 static uint64_t *update_mlat;
@@ -50,7 +50,7 @@ static uint32_t *NBinnerCycle;
 
 static uint64_t *MaskMode;
 
-static FUNCTION_PARAMETER_STRUCT FPS_DMcomb;
+static FPS FPS_DMcomb;
 
 static uint32_t *DMMODE;
 

--- a/computeCalib/compute_control_modes.c
+++ b/computeCalib/compute_control_modes.c
@@ -41,9 +41,9 @@ static float alignOD; // Outer diameter
 static uint32_t DMxsize;
 static uint32_t DMysize;
 
-static FUNCTION_PARAMETER_STRUCT FPS_zRMacqu;
-static FUNCTION_PARAMETER_STRUCT FPS_loRMacqu;
-static FUNCTION_PARAMETER_STRUCT FPS_DMcomb;
+static FPS FPS_zRMacqu;
+static FPS FPS_loRMacqu;
+static FPS FPS_DMcomb;
 
 static char fname_DMmaskCTRL[FUNCTION_PARAMETER_STRMAXLEN];
 static char fname_DMmaskEXTR[FUNCTION_PARAMETER_STRMAXLEN];


### PR DESCRIPTION
## Summary

This PR updates the Cacao plugin ecosystem to align with the modernized MILK V2 framework architecture by adopting the new `FPS` typedef and connection APIs. 

## Changes

### `AOloopControl` / `computeCalib`
- Replaced legacy `FUNCTION_PARAMETER_STRUCT` with `FPS` and `FUNCTION_PARAMETER` with `FPS_PARAM` across all compute loops and modules.
- Replaced the verbose `function_parameter_struct_connect/disconnect` calls with the streamlined `fps_connect` and `fps_disconnect` macros/functions.

## Verification

- [x] Build passes (`/compile-test` executed from the `milk` root directory successfully rebuilds Cacao plugins)

## Prompt Summary

Following the modernization of the upstream MILK framework, the user requested to propagate the legacy FPS syntax cleanup (transitioning to `FPS` and `FPS_PARAM` types) across the ecosystem, including the Cacao plugin repository.

## AI Authorship

- **Model**: Antigravity
- **User edits**: None