### PR TITLE
refactor: decouple 3 cacao compute files from CLIcore.h

### DIFF
--- a/AOloopControl_PredictiveControl/AOloopControl_PredictiveControl_mapPredictiveFilter.c
+++ b/AOloopControl_PredictiveControl/AOloopControl_PredictiveControl_mapPredictiveFilter.c
@@ -10,7 +10,13 @@
 
 #define _GNU_SOURCE
 
+#include <stdio.h>
+
+#ifdef MILK_NO_CLI
+#include "CLIcore_standalone.h"
+#else
 #include "CLIcore.h"
+#endif
 
 #include "COREMOD_memory/COREMOD_memory.h"
 
@@ -41,18 +47,17 @@ errno_t AOloopControl_PredictiveControl_mapPredictiveFilter(
     modeouto   = modeout - modeoffset;
 
     IDmodecoeff = image_ID(IDmodecoeff_name,
-        data.core.image,
-        data.core.NB_MAX_IMAGE);
-    NBmodes     = data.core.image[IDmodecoeff].md[0].size[0];
-    NBsamples   = data.core.image[IDmodecoeff].md[0].size[2];
+        dcimg, dcnimg);
+    NBmodes     = dcimg[IDmodecoeff].md[0].size[0];
+    NBsamples   = dcimg[IDmodecoeff].md[0].size[2];
 
     // reformat measurements
     create_2Dimage_ID("trace", NBsamples, modesize, &IDtrace);
 
     for(ii = 0; ii < NBsamples; ii++)
         for(m = 0; m < modesize; m++)
-            data.core.image[IDtrace].array.F[m * NBsamples + ii] =
-                data.core.image[IDmodecoeff].array.F[ii * NBmodes + m];
+            dcimg[IDtrace].array.F[m * NBsamples + ii] =
+                dcimg[IDmodecoeff].array.F[ii * NBmodes + m];
 
     AOloopControl_PredictiveControl_testPredictiveFilter("trace",
             modeouto,

--- a/AOloopControl_PredictiveControl/AOloopControl_PredictiveControl_setPFsimpleAve.c
+++ b/AOloopControl_PredictiveControl/AOloopControl_PredictiveControl_setPFsimpleAve.c
@@ -11,9 +11,14 @@
 #define _GNU_SOURCE
 
 #include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
 
+#ifdef MILK_NO_CLI
+#include "CLIcore_standalone.h"
+#else
 #include "CLIcore.h"
-
+#endif
 #include "COREMOD_memory/COREMOD_memory.h"
 
 /**
@@ -34,9 +39,9 @@ imageID AOloopControl_PredictiveControl_setPFsimpleAve(char *IDPF_name,
     float  *coeff;
     float   total;
 
-    IDPF        = image_ID(IDPF_name, data.core.image, data.core.NB_MAX_IMAGE);
-    xsize       = data.core.image[IDPF].md[0].size[0];
-    ysize       = data.core.image[IDPF].md[0].size[1];
+    IDPF        = image_ID(IDPF_name, dcimg, dcnimg);
+    xsize       = dcimg[IDPF].md[0].size[0];
+    ysize       = dcimg[IDPF].md[0].size[1];
     FilterOrder = xsize / ysize;
 
     coeff = (float *) malloc(sizeof(float) * FilterOrder);
@@ -65,11 +70,11 @@ imageID AOloopControl_PredictiveControl_setPFsimpleAve(char *IDPF_name,
         for(ii = 0; ii < ysize; ii++)
             for(jj = 0; jj < ysize; jj++)
             {
-                data.core.image[IDPF].array.F[jj * xsize + ii + kk * ysize] = 0.0f;
+                dcimg[IDPF].array.F[jj * xsize + ii + kk * ysize] = 0.0f;
             }
         for(ii = 0; ii < ysize; ii++)
         {
-            data.core.image[IDPF].array.F[ii * xsize + ii + kk * ysize] = coeff[kk];
+            dcimg[IDPF].array.F[ii * xsize + ii + kk * ysize] = coeff[kk];
         }
     }
 

--- a/computeCalib/modes_spatial_extrapolate.c
+++ b/computeCalib/modes_spatial_extrapolate.c
@@ -4,11 +4,14 @@
  */
 
 #include <math.h>
+#include <stdio.h>
 
+#ifdef MILK_NO_CLI
+#include "CLIcore_standalone.h"
+#else
 #include "CLIcore.h"
+#endif
 #include "COREMOD_memory/COREMOD_memory.h"
-
-#include "COREMOD_iofits/COREMOD_iofits.h"
 
 
 errno_t modes_spatial_extrapolate(IMGID imgmodes,
@@ -22,19 +25,22 @@ errno_t modes_spatial_extrapolate(IMGID imgmodes,
 
     resolveIMGID(
         &imgmodes, ERRMODE_WARN,
-        data.core.image,
-        data.core.NB_MAX_IMAGE);
-        if (imgmodes.ID == -1) return RETURN_FAILURE;
+        dcimg, dcnimg);
+    if (imgmodes.ID == -1) {
+        return RETURN_FAILURE;
+    }
     resolveIMGID(
         &imgmask, ERRMODE_WARN,
-        data.core.image,
-        data.core.NB_MAX_IMAGE);
-        if (imgmask.ID == -1) return RETURN_FAILURE;
+        dcimg, dcnimg);
+    if (imgmask.ID == -1) {
+        return RETURN_FAILURE;
+    }
     resolveIMGID(
         &imgcpa, ERRMODE_WARN,
-        data.core.image,
-        data.core.NB_MAX_IMAGE);
-        if (imgcpa.ID == -1) return RETURN_FAILURE;
+        dcimg, dcnimg);
+    if (imgcpa.ID == -1) {
+        return RETURN_FAILURE;
+    }
 
     imcreatelikewiseIMGID(imgoutmodes, &imgmodes);
 


### PR DESCRIPTION
## Summary

Adds `#ifdef MILK_NO_CLI` dual-mode include guards to 3 pure compute files and replaces all `data.core.image[]` / `data.core.NB_MAX_IMAGE` accesses with the portable `dcimg[]` / `dcnimg` macros. This enables these files to compile cleanly in standalone (`MILK_NO_CLI`) builds without pulling in CLIcore.

## Changes

### Files Modified (3)
- `computeCalib/modes_spatial_extrapolate.c` — 6 `data.` refs → `dcimg`/`dcnimg`; fixed brace style on `resolveIMGID` error checks
- `AOloopControl_PredictiveControl/AOloopControl_PredictiveControl_mapPredictiveFilter.c` — 6 `data.` refs → `dcimg`/`dcnimg`
- `AOloopControl_PredictiveControl/AOloopControl_PredictiveControl_setPFsimpleAve.c` — 5 `data.` refs → `dcimg`/`dcnimg`

### Include Pattern
Since cacao files use COREMOD functions (`create_2Dimage_ID`, `delete_image`, `image_ID`), the `#else` (library) path retains `CLIcore.h`. The decoupling benefit is in the `#ifdef MILK_NO_CLI` standalone path:
```c
#ifdef MILK_NO_CLI
#include "CLIcore_standalone.h"
#else
#include "CLIcore.h"
#endif
```

### Not Changed (Deferred)
4 files with deep `data.` coupling (18–89 refs including signal handlers and processinfo) are deferred to a future refactoring phase.

## Verification
- [x] Build passes (`make -j`)
- [x] Tests pass (`ctest` 38/38)

## Prompt Summary
The user requested Phase 3.2 of the dependency decoupling roadmap: applying the `_compute` library pattern to cacao AO loop control modules.

## AI Authorship
- **Model**: Antigravity
- **User edits**: None